### PR TITLE
carousel links css fix

### DIFF
--- a/idr_gallery/data/background_images.py
+++ b/idr_gallery/data/background_images.py
@@ -1,3 +1,4 @@
+# flake8: noqa
 
 IDR_IMAGES = [
     {

--- a/idr_gallery/data/tabs.py
+++ b/idr_gallery/data/tabs.py
@@ -1,3 +1,5 @@
+# flake8: noqa
+
 TABS = [
     {
         "title": "Exploring IDR",

--- a/idr_gallery/gallery_settings.py
+++ b/idr_gallery/gallery_settings.py
@@ -48,7 +48,27 @@ GALLERY_SETTINGS_MAPPING = {
 
     "omero.web.gallery.category_queries":
         ["CATEGORY_QUERIES",
-         ('{"others":{ "label": "Others", "query": "LAST200:date", "index": 10 },"lightsheet":{"label":"Light-sheet imaging","index":0,"query":"Imaging Method:light sheet fluorescence microscopy OR Imaging Method:light sheet fluorescence microscopy, SPIM"},"infection":{"label":"Infection studies","index":1,"query":"Study Type:infection"},"timelapse":{"label":"Time-lapse imaging","index":2,"query":"Study Type:time OR Study Type:5D OR Study Type:3D-tracking"},"lightsheet":{"label":"Light sheet fluorescence microscopy","index":3,"query":"Imaging Method: light sheet fluorescence microscopy OR Imaging Method: light sheet fluorescence microscopy, SPIM"},"proteinlocalization":{"label":"Protein localization studies","index":4,"query":"Study Type:protein localization"},"histology":{"label":"Digital pathology imaging","index":5,"query":"Study Type:histology"},"yeast":{"label":"Yeast studies","index":6,"query":"Organism: Saccharomyces cerevisiae OR Organism:Schizosaccharomyces pombe"},"humancellscreen":{"label":"High-content screening (human)","index":7,"query":"Organism:Homo sapiens AND Study Type:high content screen"}}'),
+         ('{"others":{ "label": "Others", "query": "LAST200:date", "index": '
+          '10 },"lightsheet":{"label":"Light-sheet imaging","index":0,'
+          '"query":'
+          '"Imaging Method:light sheet fluorescence microscopy OR '
+          'Imaging Method:light sheet fluorescence microscopy, SPIM"},'
+          '"infection":{"label":'
+          '"Infection studies","index":1,"query":"Study Type:infection"},'
+          '"timelapse":{"label":"Time-lapse imaging","index":2,"query":'
+          '"Study Type:time OR Study Type:5D OR Study Type:3D-tracking"}'
+          ',"lightsheet":{"label":"Light sheet fluorescence microscopy",'
+          '"index":3,"query":"Imaging Method: light sheet fluorescence '
+          'microscopy OR Imaging Method:'
+          'light sheet fluorescence microscopy, SPIM"},"proteinlocalization":'
+          '{"label":"Protein localization studies","index":4,"query":'
+          '"Study Type:protein localization"},"histology":{"label":'
+          '"Digital pathology imaging","index":5,"query":"Study Type:'
+          'histology"},"yeast":{"label":"Yeast studies"'
+          ',"index":6,"query":"Organism: Saccharomyces cerevisiae OR Organism:'
+          'Schizosaccharomyces pombe"},"humancellscreen":{"label":'
+          '"High-content screening (human)","index":7,"query":"Organism:'
+          'Homo sapiens AND Study Type:high content screen"}}'),
          json.loads,
          ("If this is configured then the gallery Home Page shows a list"
           " of categories containing Projects and Screens that match the"
@@ -61,7 +81,10 @@ GALLERY_SETTINGS_MAPPING = {
 
     "omero.web.gallery.filter_keys":
         ["FILTER_KEYS",
-         ('[{"label": "Name (IDR number)", "value": "Name" }, "Imaging Method", "License", "Organism", "Publication Authors", "Publication Title", "Screen Technology Type", "Screen Type", "Study Type"]'),
+         ('[{"label": "Name (IDR number)", "value": "Name" }, '
+          '"Imaging Method", "License", "Organism", "Publication Authors", '
+          '"Publication Title", "Screen Technology Type", "Screen Type",'
+          '"Study Type"]'),
          json.loads,
          ("If this is configured then we allow filtering of Screens and"
           " Projects by Key:Value pairs linked to them. This list allows us"
@@ -88,7 +111,9 @@ GALLERY_SETTINGS_MAPPING = {
 
     "omero.web.gallery.super_categories":
         ["SUPER_CATEGORIES",
-         ('{"cell": {"label": "Cell - IDR","title": "Welcome to Cell-IDR","query": "Sample Type:cell"},"tissue": {"label": "Tissue - IDR","title": "Welcome to Tissue-IDR","query": "Sample Type:tissue"}}'),
+         ('{"cell": {"label": "Cell - IDR","title": "Welcome to Cell-IDR",'
+          '"query": "Sample Type:cell"},"tissue": {"label": "Tissue - IDR",'
+          '"title": "Welcome to Tissue-IDR","query": "Sample Type:tissue"}}'),
          json.loads,
          ("Optional config to provide top-level categories, similar to"
           " category_queries, using the same config format and 'query' syntax."
@@ -102,7 +127,26 @@ GALLERY_SETTINGS_MAPPING = {
 
     "omero.web.gallery.top_right_links":
         ["TOP_RIGHT_LINKS",
-         ('[{"text":"About","href":"https://idr.openmicroscopy.org/about/index.html","submenu":[{"text":"Overview","href":"https://idr.openmicroscopy.org/about/index.html"},{"text":"Published studies","href":"https://idr.openmicroscopy.org/about/studies.html"},{"text":"Linked resources","href":"https://idr.openmicroscopy.org/about/linked-resources.html"},{"text":"API Access","href":"https://idr.openmicroscopy.org/about/api.html"},{"text":"Data download","href":"https://idr.openmicroscopy.org/about/download.html"},{"text":"Image Tools Resource (ITR)","href":"https://idr.openmicroscopy.org/about/itr.html"},{"text":"Analysis Environments","href":"https://idr.openmicroscopy.org/about/analysis-environments.html"},{"text":"Deployment","href":"https://idr.openmicroscopy.org/about/deployment.html"},{"text":"FAQ","href":"https://idr.openmicroscopy.org/about/faq/"}]},{"text":"Submissions","href":"https://idr.openmicroscopy.org/about/submission.html","submenu":[{"text":"Overview","href":"https://idr.openmicroscopy.org/about/submission.html"},{"text":"Screens","href":"https://idr.openmicroscopy.org/about/screens.html"},{"text":"Experiments","href":"https://idr.openmicroscopy.org/about/experiments.html"}]}]'),
+         ('[{"text":"About","href":"https://idr.openmicroscopy.org/about/'
+          'index.html","submenu":[{"text":"Overview","href":"https://idr.'
+          'openmicroscopy.org/about/index.html"},{"text":"Published studies"'
+          ',"href":"https://idr.openmicroscopy.org/about/studies.html"},'
+          '{"text":"Linked resources","href":"https://idr.openmicroscopy.org'
+          '/about/linked-resources.html"},{"text":"API Access","href":'
+          '"https://idr.openmicroscopy.org/about/api.html"},{"text":"Data '
+          'download","href":"https://idr.openmicroscopy.org/about/download.'
+          'html"},{"text":"Image Tools Resource (ITR)","href":"https://idr.'
+          'openmicroscopy.org/about/itr.html"},{"text":"Analysis Environments"'
+          ',"href":"https://idr.openmicroscopy.org/about/analysis-environments'
+          '.html"},{"text":"Deployment","href":"https://idr.openmicroscopy.org'
+          '/about/deployment.html"},{"text":"FAQ","href":"https://idr.open'
+          'microscopy.org/about/faq/"}]},{"text":"Submissions","href":'
+          '"https://idr.openmicroscopy.org/about/submission.html","submenu":'
+          '[{"text":"Overview","href":"https://idr.openmicroscopy.org/about/'
+          'submission.html"},{"text":"Screens","href":"https://idr.'
+          'openmicroscopy.org/about/screens.html"},{"text":"Experiments",'
+          '"href":"https://idr.openmicroscopy.org/about/experiments.html"'
+          '}]}]'),
          json.loads,
          ("List of {'text':'Text','href':'www.url'} links for top-right of"
           " page. If a link contains 'submenu':[ ] with more links,"
@@ -110,7 +154,8 @@ GALLERY_SETTINGS_MAPPING = {
 
     "omero.web.gallery.top_left_logo":
         ["TOP_LEFT_LOGO",
-         ('{"src": "https://idr.openmicroscopy.org/about/img/logos/logo-idr.svg","href": "/"}'),
+         ('{"src": "https://idr.openmicroscopy.org/about/img/logos/logo-idr'
+          '.svg","href": "/"}'),
          json.loads,
          ("Logo image and link. e.g."
           " {'src':'url.png','href':'www.url', 'alt':'Image alt text'}"
@@ -138,10 +183,10 @@ GALLERY_SETTINGS_MAPPING = {
 
     "omero.web.gallery.idr_studies_url":
         ["IDR_STUDIES_URL",
-         'https://raw.githubusercontent.com/IDR/idr.openmicroscopy.org/master/_data/studies.tsv',
+         'https://raw.githubusercontent.com/IDR/idr.openmicroscopy.org/master'
+         '/_data/studies.tsv',
          str,
-         "URL to IDR studies as a tsv table"
-        ],
+         "URL to IDR studies as a tsv table"],
 
 }
 

--- a/idr_gallery/templates/idr_gallery/background_carousel.html
+++ b/idr_gallery/templates/idr_gallery/background_carousel.html
@@ -26,6 +26,8 @@
         color: white;
         font-size: 200%;
         display: flex;
+        /* needs to be above main header content when narrow screen width */
+        z-index: 10;
     }
 
     .bg_controls div {

--- a/idr_gallery/urls.py
+++ b/idr_gallery/urls.py
@@ -11,7 +11,8 @@ urlpatterns = [
     url(r'^gallery_settings/$', views.gallery_settings),
 
     # Search page shows Projects / Screens filtered by Map Annotation
-    url(r'^search/$', views.index, {'super_category': None, 'template': 'idr_gallery/search.html'}),
+    url(r'^search/$', views.index, {
+        'super_category': None, 'template': 'idr_gallery/search.html'}),
 
     # Supports e.g. ?project=1&project=2&screen=3
     url(r'^gallery-api/thumbnails/$', views.api_thumbnails,
@@ -22,4 +23,5 @@ for c in SUPER_CATEGORIES:
     urlpatterns.append(url(r'^%s/$' % c, views.index, {'super_category': c},
                            name="gallery_super_category"))
     urlpatterns.append(url(r'^%s/search/$' % c, views.index,
-                           {'super_category': c, 'template': 'idr_gallery/search.html'}))
+                           {'super_category': c,
+                            'template': 'idr_gallery/search.html'}))

--- a/idr_gallery/views.py
+++ b/idr_gallery/views.py
@@ -1,4 +1,3 @@
-from django.http import Http404
 from django.urls import reverse, NoReverseMatch
 import json
 import logging
@@ -22,6 +21,7 @@ from .version import VERSION
 
 logger = logging.getLogger(__name__)
 MAX_LIMIT = max(1, API_MAX_LIMIT)
+
 
 @login_required()
 @render_response()
@@ -102,7 +102,8 @@ def gallery_settings(request):
     return context
 
 
-def _get_study_images(conn, obj_type, obj_id, limit=1, offset=0, tag_text=None):
+def _get_study_images(conn, obj_type, obj_id, limit=1,
+                      offset=0, tag_text=None):
 
     query_service = conn.getQueryService()
     params = omero.sys.ParametersI()
@@ -132,8 +133,8 @@ def _get_study_images(conn, obj_type, obj_id, limit=1, offset=0, tag_text=None):
                  " join well.plate as pt"
                  " left outer join pt.screenLinks as sl"
                  " join sl.parent as screen"
-                 " left outer join i.annotationLinks as al"\
-                 " join al.child as annotation"\
+                 " left outer join i.annotationLinks as al"
+                 " join al.child as annotation"
                  " where screen.id = :id%s"
                  " order by well.column, well.row" % and_text_value)
 
@@ -155,7 +156,8 @@ def api_thumbnails(request, conn=None, **kwargs):
     image_ids = {}
     for obj_type, ids in zip(['project', 'screen'], [project_ids, screen_ids]):
         for obj_id in ids:
-            images = _get_study_images(conn, obj_type, obj_id, tag_text="Study Example Image")
+            images = _get_study_images(conn, obj_type, obj_id,
+                                       tag_text="Study Example Image")
             if len(images) == 0:
                 # None found with Tag - just load untagged image
                 images = _get_study_images(conn, obj_type, obj_id)

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ import os
 from setuptools import setup, find_packages
 from idr_gallery.version import VERSION
 
+
 # Utility function to read the README file.
 # Used for the long_description.  It's nice, because now 1) we have a top level
 # README file and 2) it's easier to type in the README file than to put a raw


### PR DESCRIPTION
This fixes an issue with the main content of the header invisibly overlapping the (i) and (eye) icons in the top-right when the page is narrow (as on a mobile phone), so that the links aren't clickable.

To test:
 - resize your browser to be as thin as possible
 - try to click on the info and eye links