### PR TITLE
fix autocomplete enter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,17 @@
-3.4.0 (March 2021)
+3.6.0 (March 2022)
+------------------
+
+- Migration and renaming fixes [#3](https://github.com/IDR/idr-gallery/pull/3)
+- Fixed carousel links [#4](https://github.com/IDR/idr-gallery/pull/4)
+- Added 3 videos [#5](https://github.com/IDR/idr-gallery/pull/5)
+
+3.5.0 (March 2022)
+------------------
+
+- The `omero-gallery` repository was forked to `idr-gallery` [#1](https://github.com/IDR/idr-gallery/pull/1)
+- New front page [#2](https://github.com/IDR/idr-gallery/pull/2)
+
+3.4.0 (March 2022)
 ------------------
 
 - Make app compatible with Django 1.11.x and 3.2.x [#74](https://github.com/ome/omero-gallery/pull/93)

--- a/idr_gallery/static/idr_gallery/autocomplete.js
+++ b/idr_gallery/static/idr_gallery/autocomplete.js
@@ -42,15 +42,19 @@ function hideSpinner() {
     document.getElementById('spinner').style.visibility = 'hidden';
 }
 
+// This is used by the home page but NOT by the search page itself
+function enableEnterGoesToResultsPage() {
+    $("#maprQuery")
+        .keyup(event => {
+            if (event.which == 13) {
+                let configId = document.getElementById("maprConfig").value;
+                document.location.href = `${GALLERY_HOME}search/?query=${configId}:${event.target.value}`;
+            }
+        });
+}
+
 // Initial setup...
 $("#maprQuery")
-    .keyup(event => {
-        if (event.which == 13) {
-            let configId = document.getElementById("maprConfig").value;
-            console.log(`${GALLERY_HOME}search/?query=${configId}:${event.target.value}`)
-            // document.location.href = `${GALLERY_HOME}search/?query=${configId}:${event.target.value}`;
-        }
-    })
     .autocomplete({
         autoFocus: false,
         delay: 1000,

--- a/idr_gallery/static/idr_gallery/categories.js
+++ b/idr_gallery/static/idr_gallery/categories.js
@@ -288,6 +288,8 @@ async function init() {
     render();
   })
 
+  // auto-complete: 'Enter' key will browse to results page
+  enableEnterGoesToResultsPage();
 
   // Load MAPR config
   fetch(BASE_URL + 'mapr/api/config/')

--- a/idr_gallery/static/idr_gallery/search.js
+++ b/idr_gallery/static/idr_gallery/search.js
@@ -458,13 +458,26 @@ function render(filterFunc) {
     studiesToRender = model.studies.filter(filterFunc);
   }
 
+  let configId = document.getElementById("maprConfig").value.replace('mapr_', '');
+  configId = (mapr_settings && mapr_settings[configId]) || configId;
+  let maprValue = document.getElementById('maprQuery').value;
+
+  if (configId === "Name") {
+    // If searching by idrID (Number)  show best match first...
+    let value = document.getElementById("maprQuery").value;
+    if (!isNaN(value)) {
+      let padZeros = ("0000" + value)
+      let idrId = `idr${padZeros.slice(padZeros.length-4)}`
+      studiesToRender.sort(function (a, b) {
+        return (a.Name.includes(idrId) ? -1 : 1);
+      });
+    }
+  }
+
   let filterMessage = "";
   if (studiesToRender.length === 0) {
     filterMessage = noStudiesMessage();
   } else if (studiesToRender.length < model.studies.length) {
-    let configId = document.getElementById("maprConfig").value.replace('mapr_', '');
-    configId = (mapr_settings && mapr_settings[configId]) || configId;
-    let maprValue = document.getElementById('maprQuery').value;
     filterMessage = `<p class="filterMessage">
       Found <strong>${studiesToRender.length}</strong> studies with
       <strong>${configId}</strong>: <strong>${maprValue}</strong></p>`;


### PR DESCRIPTION
As reported by @francesw, the new front page had a change of behaviour for the autocomplete:

To test:

- On the front page, when you enter some text in the autocomplete and hit `Enter` - you should be sent to the `/search` results page.

- On the `/search` page itself, this shouldn't happen (browser shouldn't refresh).