### PR TITLE
Search front page

### DIFF
--- a/idr_gallery/static/idr_gallery/autocomplete.js
+++ b/idr_gallery/static/idr_gallery/autocomplete.js
@@ -1,6 +1,35 @@
 // ------ AUTO-COMPLETE -------------------
 
-const KNOWN_KEYS = {"image":["Antibody","siRNA Pool Identifier","PubChem CID","Pathology Identifier","Cell Line","Antibody Identifier","Organism Part","InChIKey","Gene Symbol","Organism","Protein","Pathology","Phenotype Term Accession","Compound Name","Gene Name","siRNA Identifier","Phenotype"],"project":["Publication Authors","Study Type","License","Publication Title","Imaging Method","Name (IDR number)"],"screen":["Screen Technology Type","Screen Type"]}
+const KNOWN_KEYS = {
+  image: [
+    "Antibody",
+    "siRNA Pool Identifier",
+    "PubChem CID",
+    "Pathology Identifier",
+    "Cell Line",
+    "Antibody Identifier",
+    "Organism Part",
+    "InChIKey",
+    "Gene Symbol",
+    "Organism",
+    "Protein",
+    "Pathology",
+    "Phenotype Term Accession",
+    "Compound Name",
+    "Gene Name",
+    "siRNA Identifier",
+    "Phenotype",
+  ],
+  project: [
+    "Publication Authors",
+    "Study Type",
+    "License",
+    "Publication Title",
+    "Imaging Method",
+    "Name (IDR number)",
+  ],
+  screen: ["Screen Technology Type", "Screen Type"],
+};
 
 document.getElementById("maprConfig").onchange = (event) => {
   document.getElementById("maprQuery").value = "";
@@ -89,8 +118,8 @@ function autocompleteSort(queryVal) {
     // Show highest Image counts first
     let aCount = a["Number of images"];
     let bCount = b["Number of images"];
-    return aCount > bCount ? -1 : (aCount < bCount ? 1 : 0);
-  }
+    return aCount > bCount ? -1 : aCount < bCount ? 1 : 0;
+  };
 }
 
 // Initial setup...
@@ -159,8 +188,14 @@ $("#maprQuery")
               .map((result) => {
                 return `<div>
                   <a target="_blank"
-                    href="https://idr-testing.openmicroscopy.org/webclient/search/?search_query=${encodeURI(result.Key)}:${encodeURI(result.Value)}">
-                    ${result["Number of images"]} Images <span style="color:#bbb">matched</span> ${result.Key}: ${result.Value.replace(queryRegex, "<mark>$&</mark>")}
+                    href="https://idr-testing.openmicroscopy.org/webclient/search/?search_query=${encodeURI(
+                      result.Key
+                    )}:${encodeURI(result.Value)}">
+                    ${
+                      result["Number of images"]
+                    } Images <span style="color:#bbb">matched</span> ${
+                  result.Key
+                }: ${result.Value.replace(queryRegex, "<mark>$&</mark>")}
                   </a></div>
                   `;
               })
@@ -234,23 +269,19 @@ function getMatchingStudiesHtml(text) {
           string
         );
       }
-      // let matchingString = matchingStrings
-      //   .map((kvp) => kvp.join(": "))
-      //   .map(markup)
-      //   .join("<br>");
       let idrId = study.Name.split("-")[0];
       let container = study.Name.split("/").pop();
 
       let imgCount = imageCount(idrId, container);
       let matchingString = "";
-      let matchingDesc = matchingStrings.find(kvp => kvp[0] == "Description");
+      let matchingDesc = matchingStrings.find((kvp) => kvp[0] == "Description");
       if (matchingDesc) {
         matchingString = markup(matchingDesc.join(": "));
       } else {
         matchingString = matchingStrings
-        .map((kvp) => kvp.join(": "))
-        .map(markup)
-        .join("<br>");
+          .map((kvp) => kvp.join(": "))
+          .map(markup)
+          .join("<br>");
       }
 
       return `<div>

--- a/idr_gallery/static/idr_gallery/autocomplete.js
+++ b/idr_gallery/static/idr_gallery/autocomplete.js
@@ -4,7 +4,7 @@ let KNOWN_KEYS = {};
 
 // immediately load keys from search engine. Used for autocomplete sorting
 url = `${BASE_URL}searchengine/api/v1/resources/all/keys/?mode=searchterms`;
-$.getJSON(url, function(data){
+$.getJSON(url, function (data) {
   KNOWN_KEYS = data;
 });
 
@@ -64,7 +64,6 @@ function enableEnterGoesToResultsPage() {
   });
 }
 
-
 function autoCompleteDisplayResults(queryVal, data) {
   // For showing the searchengine results in a panel
   let queryRegex = new RegExp(queryVal, "ig"); // ignore-case, global
@@ -95,7 +94,8 @@ function autoCompleteDisplayResults(queryVal, data) {
     .join("\n");
 
   if (studiesHtml.length == 0 && imagesHtml == 0) {
-    document.getElementById("imageSearchResults").innerHTML = "No matches found";
+    document.getElementById("imageSearchResults").innerHTML =
+      "No matches found";
   } else {
     let html = `<div class="searchScroll scrollBarVisible">${imagesHtml}</div>`;
     document.getElementById("imageSearchResults").innerHTML = html;
@@ -189,7 +189,6 @@ $("#maprQuery")
         data: requestData,
         success: function (data) {
           hideSpinner();
-          console.log("data", data);
           let queryVal = $("#maprQuery").val().trim();
           let results = [];
           if (configId === "any") {
@@ -197,9 +196,6 @@ $("#maprQuery")
           } else {
             results = data;
           }
-          // if (results.length === 0) {
-          //   results = [{ label: "No results found.", value: -1 }];
-          // }
           response(results);
         },
         error: function (data) {
@@ -216,7 +212,6 @@ $("#maprQuery")
     minLength: 0,
     open: function () {},
     close: function () {
-      // $(this).val('');
       return false;
     },
     focus: function (event, ui) {},
@@ -238,7 +233,6 @@ $("#maprQuery")
     },
   })
   .data("ui-autocomplete")._renderItem = function (ul, item) {
-  console.log("item", item.label);
   return $("<li>")
     .append("<a>" + item.label + "</a>")
     .appendTo(ul);
@@ -305,15 +299,6 @@ function getMatchingStudiesHtml(text) {
 
   if (results.length == 0) {
     html = "";
-    // if (SUPER_CATEGORY) {
-    //   if (SUPER_CATEGORY.id === "cell") {
-    //     html += ` in Cell IDR. Try searching <a href="${GALLERY_INDEX}">all Studies in IDR</a>.`;
-    //   } else if (SUPER_CATEGORY.id === "tissue") {
-    //     html += ` in Tissue IDR. Try searching <a href="${GALLERY_INDEX}">all Studies in IDR</a>.`;
-    //   }
-    // } else {
-    //   html += ". Try searching for Image attributes above."
-    // }
   } else {
     html = `<div class="searchScroll scrollBarVisible">${html}</div>`;
   }

--- a/idr_gallery/static/idr_gallery/autocomplete.js
+++ b/idr_gallery/static/idr_gallery/autocomplete.js
@@ -12,6 +12,8 @@ document.getElementById("maprConfig").onchange = (event) => {
   document.getElementById("maprQuery").value = "";
   let value = event.target.value.replace("mapr_", "");
   let placeholder = `Type to filter values...`;
+  // hide any previous search-engine results
+  $("#searchResultsContainer").hide();
   if (mapr_settings[value]) {
     placeholder = `Type ${mapr_settings[value]["default"][0]}...`;
   } else if (value == "any") {

--- a/idr_gallery/static/idr_gallery/autocomplete.js
+++ b/idr_gallery/static/idr_gallery/autocomplete.js
@@ -72,6 +72,28 @@ $("#maprQuery").on("keyup", function (event) {
   $("#searchResultsContainer").show();
 });
 
+function autocompleteSort(queryVal) {
+  // returns a sort function based on the current query Value
+  return (a, b) => {
+    // if exact match, show first
+    let aMatch = queryVal == a.Value;
+    let bMatch = queryVal == b.Value;
+    if (aMatch != bMatch) {
+      return aMatch ? -1 : 1;
+    }
+    // show all known Keys before unknown
+    let aKnown = KNOWN_KEYS.image.includes(a.Key);
+    let bKnown = KNOWN_KEYS.image.includes(b.Key);
+    if (aKnown != bKnown) {
+      return aKnown ? -1 : 1;
+    }
+    // Show highest Image counts first
+    let aCount = a["Number of images"];
+    let bCount = b["Number of images"];
+    return aCount > bCount ? -1 : (aCount < bCount ? 1 : 0);
+  }
+}
+
 // Initial setup...
 $("#maprQuery")
   .autocomplete({
@@ -132,21 +154,7 @@ $("#maprQuery")
           let results = [];
           if (configId === "any") {
             let results = [...data.data];
-            results.sort((a, b) => {
-              // if exact match, show first
-              if (queryVal == a.Value) return -1;
-              if (queryVal == b.Value) return 1;
-              // show all known Keys before unknown
-              let aKnown = KNOWN_KEYS.image.includes(a.Key);
-              let bKnown = KNOWN_KEYS.image.includes(b.Key);
-              if (aKnown != bKnown) {
-                return aKnown ? -1 : 1;
-              }
-              // Show highest Image counts first
-              let aCount = a["Number of images"];
-              let bCount = b["Number of images"];
-              return aCount > bCount ? -1 : (aCount < bCount ? 1 : 0);
-            });
+            results.sort(autocompleteSort(queryVal));
             let imagesHtml = results
               .map((result) => {
                 return `<li><a target="_blank" href="https://idr-testing.openmicroscopy.org/webclient/search/?search_query=${encodeURI(

--- a/idr_gallery/static/idr_gallery/autocomplete.js
+++ b/idr_gallery/static/idr_gallery/autocomplete.js
@@ -75,12 +75,13 @@ function enableEnterGoesToResultsPage() {
 }
 
 function escapeRegExp(string) {
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#escaping
   return string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"); // $& means the whole matched string
 }
 
 function autoCompleteDisplayResults(queryVal, data) {
   // For showing the searchengine results in a panel
-  let queryRegex = new RegExp(queryVal, "ig"); // ignore-case, global
+  let queryRegex = new RegExp(escapeRegExp(queryVal), "ig"); // ignore-case, global
 
   // Search-engine results...
   let results = [...data.data];
@@ -271,9 +272,9 @@ function getMatchingStudiesHtml(text, highlightStudy) {
     .map((studyText, index) => {
       let [study, matchingStrings] = studyText;
 
-      let regex = new RegExp(text.trim(), "i");
+      let regex = new RegExp(escapeRegExp(text.trim()), "i");
       function markup(string) {
-        let marked = escapeRegExp(string).replace(regex, "<mark>$&</mark>");
+        let marked = string.replace(regex, "<mark>$&</mark>");
         // truncate to include <mark> and text either side
         let start = marked.indexOf("<mark>");
         let end = marked.lastIndexOf("</mark>");

--- a/idr_gallery/static/idr_gallery/autocomplete.js
+++ b/idr_gallery/static/idr_gallery/autocomplete.js
@@ -151,25 +151,22 @@ $("#maprQuery")
           hideSpinner();
           console.log("data", data);
           let queryVal = $("#maprQuery").val();
+          let queryRegex = new RegExp(queryVal, "ig"); // ignore-case, global
           let results = [];
           if (configId === "any") {
             let results = [...data.data];
             results.sort(autocompleteSort(queryVal));
             let imagesHtml = results
               .map((result) => {
-                return `<li><a target="_blank" href="https://idr-testing.openmicroscopy.org/webclient/search/?search_query=${encodeURI(
-                  result.Key
-                )}:${encodeURI(result.Value)}">
-                    <b>${result.Value}</b> (${
-                  result.Key
-                }) <span style="color:#bbb">${
-                  result["Number of images"]
-                } images</span>
-                  </a></li>
+                return `<div style="margin: 10px 0">
+                  <a target="_blank"
+                    href="https://idr-testing.openmicroscopy.org/webclient/search/?search_query=${encodeURI(result.Key)}:${encodeURI(result.Value)}">
+                    ${result["Number of images"]} Images <span style="color:#bbb">matched</span> ${result.Key}: ${result.Value.replace(queryRegex, "<mark>$&</mark>")}
+                  </a></div>
                   `;
               })
-              .join("<br>");
-            let html = `<h2>Images</h2><div class="searchScroll scrollBarVisible"><ul>${imagesHtml}</ul></div>`;
+              .join("\n");
+            let html = `<h2>Images</h2><div class="searchScroll scrollBarVisible">${imagesHtml}</div>`;
             document.getElementById("imageSearchResults").innerHTML = html;
           } else {
             results = data;

--- a/idr_gallery/static/idr_gallery/autocomplete.js
+++ b/idr_gallery/static/idr_gallery/autocomplete.js
@@ -160,8 +160,8 @@ $("#maprQuery")
       };
       let url;
       if (configId === "any") {
-        // Use searchengine... #TODO: make configurable
-        url = `https://idr-testing.openmicroscopy.org/searchengine/api/v1/resources/image/searchvalues/`;
+        // Use searchengine...
+        url = `${BASE_URL}searchengine/api/v1/resources/image/searchvalues/`;
         requestData = { value: request.term };
       } else {
         // Use mapr to find auto-complete matches
@@ -190,7 +190,7 @@ $("#maprQuery")
               .map((result) => {
                 return `<div>
                   <a target="_blank"
-                    href="https://idr-testing.openmicroscopy.org/webclient/search/?search_query=${encodeURI(
+                    href="${BASE_URL}webclient/search/?search_query=${encodeURI(
                       result.Key
                     )}:${encodeURI(result.Value)}">
                     ${

--- a/idr_gallery/static/idr_gallery/autocomplete.js
+++ b/idr_gallery/static/idr_gallery/autocomplete.js
@@ -67,8 +67,7 @@ $("#maprQuery").on("keyup", function (event) {
   }
   let input = event.target.value.trim();
   let studiesHtml = getMatchingStudiesHtml(input);
-  let html = `<h2>Studies</h2><ul>${studiesHtml}</ul>`;
-  document.getElementById("studySearchResults").innerHTML = html;
+  document.getElementById("studySearchResults").innerHTML = studiesHtml;
   $("#searchResultsContainer").show();
 });
 
@@ -158,7 +157,7 @@ $("#maprQuery")
             results.sort(autocompleteSort(queryVal));
             let imagesHtml = results
               .map((result) => {
-                return `<div style="margin: 10px 0">
+                return `<div>
                   <a target="_blank"
                     href="https://idr-testing.openmicroscopy.org/webclient/search/?search_query=${encodeURI(result.Key)}:${encodeURI(result.Value)}">
                     ${result["Number of images"]} Images <span style="color:#bbb">matched</span> ${result.Key}: ${result.Value.replace(queryRegex, "<mark>$&</mark>")}
@@ -166,7 +165,7 @@ $("#maprQuery")
                   `;
               })
               .join("\n");
-            let html = `<h2>Images</h2><div class="searchScroll scrollBarVisible">${imagesHtml}</div>`;
+            let html = `<div class="searchScroll scrollBarVisible">${imagesHtml}</div>`;
             document.getElementById("imageSearchResults").innerHTML = html;
           } else {
             results = data;
@@ -235,30 +234,30 @@ function getMatchingStudiesHtml(text) {
           string
         );
       }
-      let matchingString = matchingStrings
+      // let matchingString = matchingStrings
+      //   .map((kvp) => kvp.join(": "))
+      //   .map(markup)
+      //   .join("<br>");
+      let idrId = study.Name.split("-")[0];
+      let container = study.Name.split("/").pop();
+
+      let imgCount = imageCount(idrId, container);
+      let matchingString = "";
+      let matchingDesc = matchingStrings.find(kvp => kvp[0] == "Description");
+      if (matchingDesc) {
+        matchingString = markup(matchingDesc.join(": "));
+      } else {
+        matchingString = matchingStrings
         .map((kvp) => kvp.join(": "))
         .map(markup)
         .join("<br>");
-      let idrId = study.Name.split("-")[0];
-      let pubmed = model.getStudyValue(study, "PubMed ID")?.split(" ")[1];
-      let authors = model.getStudyValue(study, "Publication Authors") || " ";
-      authors = authors.split(",")[0];
+      }
 
-      return `<tr style="font-size: 13px">
-        <td>
-          ${idrId}<br>
-          <span style="white-space:nowrap">${
-            pubmed
-              ? `<a target="_blank" href="${pubmed}"> ${authors} et. al </a>`
-              : `<b> ${authors} et. al </b>`
-          }</span><br>
-          <a target="_blank" href="${BASE_URL}webclient/?show=${study.objId}">
-            <img src="${study.thumbnail}"/><br>
-            ${study.Name.split("/").pop()}
-          </a>
-        </td>
-        <td>${matchingString}</td>
-        </tr>`;
+      return `<div>
+        <a target="_blank" href="${BASE_URL}webclient/?show=${study.objId}">Study ${idrId}</a>
+        (${imgCount})
+        <span style="color:#bbb">matched</span> ${matchingString}
+        </div>`;
     })
     .join("\n");
 
@@ -274,15 +273,8 @@ function getMatchingStudiesHtml(text) {
     //   html += ". Try searching for Image attributes above."
     // }
   } else {
-    html = `<div class="searchScroll scrollBarVisible"><table><tbody>${html}</tbody></table></div>`;
+    html = `<div class="searchScroll scrollBarVisible">${html}</div>`;
   }
 
-  let containerCount = results.length;
-  let idrIds = results.map((r) => r[0].Name.split("-")[0]);
-  let studyCount = new Set(idrIds).size;
-
-  html =
-    `<div class="resultCounts">found ${containerCount} containers in ${studyCount} studies</div>` +
-    html;
   return html;
 }

--- a/idr_gallery/static/idr_gallery/autocomplete.js
+++ b/idr_gallery/static/idr_gallery/autocomplete.js
@@ -190,9 +190,9 @@ $("#maprQuery")
             let imagesHtml = results
               .map((result) => {
                 // TODO: define how to encode query in search URL to support AND/OR clauses
-                let result_url = `${GALLERY_HOME}search/?search_query=${encodeURI(
+                let result_url = `${GALLERY_HOME}search/?key=${encodeURI(
                   result.Key
-                )}:${encodeURI(result.Value)}`;
+                )}&value=${encodeURI(result.Value)}&operator=equals`;
                 return `<div>
                   <a target="_blank"
                     href="${result_url}">

--- a/idr_gallery/static/idr_gallery/autocomplete.js
+++ b/idr_gallery/static/idr_gallery/autocomplete.js
@@ -108,7 +108,7 @@ function autoCompleteDisplayResults(queryVal, data) {
                       result["Number of images"]
                     } Images <span style="color:#bbb">matched</span> <span class="black">${
         result.Key
-      }:</span> ${escapeRegExp(result.Value).replace(
+      }:</span> ${result.Value.replace(
         queryRegex,
         "<mark>$&</mark>"
       )}

--- a/idr_gallery/static/idr_gallery/autocomplete.js
+++ b/idr_gallery/static/idr_gallery/autocomplete.js
@@ -38,7 +38,7 @@ document.getElementById("maprConfig").onchange = (event) => {
   if (mapr_settings[value]) {
     placeholder = `Type ${mapr_settings[value]["default"][0]}...`;
   } else if (value == "any") {
-    placeholder = "Search for anything..."
+    placeholder = "Search for anything...";
   }
   document.getElementById("maprQuery").placeholder = placeholder;
   // Show all autocomplete options...
@@ -188,11 +188,13 @@ $("#maprQuery")
             results.sort(autocompleteSort(queryVal));
             let imagesHtml = results
               .map((result) => {
+                // TODO: define how to encode query in search URL to support AND/OR clauses
+                let result_url = `${GALLERY_HOME}search/?search_query=${encodeURI(
+                  result.Key
+                )}:${encodeURI(result.Value)}`;
                 return `<div>
                   <a target="_blank"
-                    href="${BASE_URL}webclient/search/?search_query=${encodeURI(
-                      result.Key
-                    )}:${encodeURI(result.Value)}">
+                    href="${result_url}">
                     ${
                       result["Number of images"]
                     } Images <span style="color:#bbb">matched</span> <span class="black">${
@@ -264,7 +266,10 @@ function getMatchingStudiesHtml(text) {
     .map((studyText) => {
       let [study, matchingStrings] = studyText;
 
-      let regexes = text.trim().split(" ").map((token) => new RegExp(token, "i"));
+      let regexes = text
+        .trim()
+        .split(" ")
+        .map((token) => new RegExp(token, "i"));
       function markup(string) {
         const marked = regexes.reduce(
           (prev, regex) => prev.replace(regex, "<mark>$&</mark>"),
@@ -275,7 +280,7 @@ function getMatchingStudiesHtml(text) {
         let end = marked.lastIndexOf("</mark>");
         let length = end - start;
         let targetLength = 80;
-        let padding = (targetLength - length)/2;
+        let padding = (targetLength - length) / 2;
         if (start - padding < 0) {
           start = 0;
         } else {
@@ -295,8 +300,8 @@ function getMatchingStudiesHtml(text) {
 
       let imgCount = imageCount(idrId, container);
       let matchingString = matchingStrings
-          .map((kvp) => `<b>${markup(kvp[0])}</b>: ${markup(kvp[1])}`)
-          .join("<br>");
+        .map((kvp) => `<b>${markup(kvp[0])}</b>: ${markup(kvp[1])}`)
+        .join("<br>");
 
       return `<a target="_blank" href="${BASE_URL}webclient/?show=${study.objId}">
       <div class="matchingStudy">

--- a/idr_gallery/static/idr_gallery/autocomplete.js
+++ b/idr_gallery/static/idr_gallery/autocomplete.js
@@ -87,20 +87,6 @@ function enableEnterGoesToResultsPage() {
   });
 }
 
-// "instant" auto-complete for 'Any' key searches Studies and shows
-// full-page results panel (the ajax search results for images are added to
-// this from the $.autocomplete response below)
-// $("#maprQuery").on("keyup", function (event) {
-//   let configId = document.getElementById("maprConfig").value;
-//   if (configId != "any") {
-//     $("#searchResultsContainer").hide();
-//     return;
-//   }
-//   let input = event.target.value.trim();
-//   let studiesHtml = getMatchingStudiesHtml(input);
-//   document.getElementById("studySearchResults").innerHTML = studiesHtml;
-//   $("#searchResultsContainer").show();
-// });
 
 function autoCompleteDisplayResults(queryVal, data) {
   // For showing the searchengine results in a panel

--- a/idr_gallery/static/idr_gallery/autocomplete.js
+++ b/idr_gallery/static/idr_gallery/autocomplete.js
@@ -77,7 +77,8 @@ function autoCompleteDisplayResults(queryVal, data) {
   let imagesHtml = results
     .map((result) => {
       // TODO: define how to encode query in search URL to support AND/OR clauses
-      let result_url = `${GALLERY_HOME}search/?key=${encodeURI(
+      let cell_tissue = SUPER_CATEGORY ? SUPER_CATEGORY.id + "/" : "";
+      let result_url = `${GALLERY_HOME}${cell_tissue}search/?key=${encodeURI(
         result.Key
       )}&value=${encodeURI(result.Value)}&operator=equals`;
       return `<div>

--- a/idr_gallery/static/idr_gallery/autocomplete.js
+++ b/idr_gallery/static/idr_gallery/autocomplete.js
@@ -1,35 +1,12 @@
 // ------ AUTO-COMPLETE -------------------
 
-const KNOWN_KEYS = {
-  image: [
-    "Antibody",
-    "siRNA Pool Identifier",
-    "PubChem CID",
-    "Pathology Identifier",
-    "Cell Line",
-    "Antibody Identifier",
-    "Organism Part",
-    "InChIKey",
-    "Gene Symbol",
-    "Organism",
-    "Protein",
-    "Pathology",
-    "Phenotype Term Accession",
-    "Compound Name",
-    "Gene Name",
-    "siRNA Identifier",
-    "Phenotype",
-  ],
-  project: [
-    "Publication Authors",
-    "Study Type",
-    "License",
-    "Publication Title",
-    "Imaging Method",
-    "Name (IDR number)",
-  ],
-  screen: ["Screen Technology Type", "Screen Type"],
-};
+let KNOWN_KEYS = {};
+
+// immediately load keys from search engine. Used for autocomplete sorting
+url = `${BASE_URL}searchengine/api/v1/resources/all/keys/?mode=searchterms`;
+$.getJSON(url, function(data){
+  KNOWN_KEYS = data;
+});
 
 document.getElementById("maprConfig").onchange = (event) => {
   document.getElementById("maprQuery").value = "";
@@ -145,8 +122,8 @@ function autocompleteSort(queryVal) {
       return aMatch ? -1 : 1;
     }
     // show all known Keys before unknown
-    let aKnown = KNOWN_KEYS.image.includes(a.Key);
-    let bKnown = KNOWN_KEYS.image.includes(b.Key);
+    let aKnown = KNOWN_KEYS?.image?.includes(a.Key);
+    let bKnown = KNOWN_KEYS?.image?.includes(b.Key);
     if (aKnown != bKnown) {
       return aKnown ? -1 : 1;
     }

--- a/idr_gallery/static/idr_gallery/autocomplete.js
+++ b/idr_gallery/static/idr_gallery/autocomplete.js
@@ -5,7 +5,7 @@ let SELECT_CLASS = "ui-state-active";
 let KNOWN_KEYS = {};
 
 // immediately load keys from search engine. Used for autocomplete sorting
-url = `${BASE_URL}searchengine/api/v1/resources/all/keys/?mode=searchterms`;
+url = `${SEARCH_ENGINE_URL}resources/all/keys/?mode=searchterms`;
 $.getJSON(url, function (data) {
   KNOWN_KEYS = data;
 });
@@ -193,7 +193,7 @@ $("#maprQuery")
       let url;
       if (configId === "any") {
         // Use searchengine...
-        url = `${BASE_URL}searchengine/api/v1/resources/image/searchvalues/`;
+        url = `${SEARCH_ENGINE_URL}resources/image/searchvalues/`;
         requestData = { value: request.term };
       } else {
         // Use mapr to find auto-complete matches TODO: to be removed

--- a/idr_gallery/static/idr_gallery/autocomplete.js
+++ b/idr_gallery/static/idr_gallery/autocomplete.js
@@ -168,9 +168,11 @@ $("#maprQuery")
       let configId = document.getElementById("maprConfig").value;
       // Don't handle empty queries
       if (request.term.trim().length == 0) {
+        response();
         return;
       }
 
+      // Old filter-by-Study-Attribute, e.g. "Name"
       if (configId.indexOf("mapr_") != 0 && configId != "any") {
         let matches;
         if (configId === "Name") {
@@ -184,7 +186,7 @@ $("#maprQuery")
         return;
       }
 
-      // Auto-complete to filter by mapr...
+      // Auto-complete to filter by mapr, or use search-engine for 'any' key...
       configId = configId.replace("mapr_", "");
       let case_sensitive = false;
 
@@ -233,7 +235,7 @@ $("#maprQuery")
         },
       });
     },
-    minLength: 0,
+    minLength: 1,
     open: function () {},
     close: function () {
       return false;
@@ -249,8 +251,9 @@ $("#maprQuery")
         // 'any' auto-complete actions handled elsewhere
         return false;
       }
-      // show temp message in case loading search page is slow
-      $(this).val("loading search results...");
+      // show spinner in case loading search page is slow
+      showSpinner();
+
       // Load search page...
       document.location.href = `${GALLERY_HOME}search/?query=${configId}:${ui.item.value}`;
       return false;

--- a/idr_gallery/static/idr_gallery/autocomplete.js
+++ b/idr_gallery/static/idr_gallery/autocomplete.js
@@ -37,6 +37,8 @@ document.getElementById("maprConfig").onchange = (event) => {
   let placeholder = `Type to filter values...`;
   if (mapr_settings[value]) {
     placeholder = `Type ${mapr_settings[value]["default"][0]}...`;
+  } else if (value == "any") {
+    placeholder = "Search for anything..."
   }
   document.getElementById("maprQuery").placeholder = placeholder;
   // Show all autocomplete options...

--- a/idr_gallery/static/idr_gallery/autocomplete.js
+++ b/idr_gallery/static/idr_gallery/autocomplete.js
@@ -80,9 +80,11 @@ function autoCompleteDisplayResults(queryVal, data) {
     .map((result) => {
       // TODO: define how to encode query in search URL to support AND/OR clauses
       let cell_tissue = SUPER_CATEGORY ? SUPER_CATEGORY.id + "/" : "";
-      let result_url = `${GALLERY_HOME}${cell_tissue}search/?key=${encodeURI(
-        result.Key
-      )}&value=${encodeURI(result.Value)}&operator=equals`;
+      let params = new URLSearchParams();
+      params.append("key", result.Key);
+      params.append("value", result.Value);
+      params.append("operator", "equals");
+      let result_url = `${GALLERY_HOME}${cell_tissue}search/?${params.toString()}`;
       return `<div>
                   <a target="_blank"
                     href="${result_url}">
@@ -194,7 +196,8 @@ $("#maprQuery")
           hideSpinner();
           let queryVal = $("#maprQuery").val().trim();
           let results = [];
-          if (configId === "any") {
+          // check that input hasn't changed during the call
+          if (configId === "any" && request.term == queryVal) {
             autoCompleteDisplayResults(queryVal, data);
           } else {
             results = data;

--- a/idr_gallery/static/idr_gallery/autocomplete.js
+++ b/idr_gallery/static/idr_gallery/autocomplete.js
@@ -108,10 +108,7 @@ function autoCompleteDisplayResults(queryVal, data) {
                       result["Number of images"]
                     } Images <span style="color:#bbb">matched</span> <span class="black">${
         result.Key
-      }:</span> ${result.Value.replace(
-        queryRegex,
-        "<mark>$&</mark>"
-      )}
+      }:</span> ${result.Value.replace(queryRegex, "<mark>$&</mark>")}
                   </a></div>
                   `;
     })
@@ -199,7 +196,7 @@ $("#maprQuery")
         url = `${BASE_URL}searchengine/api/v1/resources/image/searchvalues/`;
         requestData = { value: request.term };
       } else {
-        // Use mapr to find auto-complete matches
+        // Use mapr to find auto-complete matches TODO: to be removed
         url = `${BASE_URL}mapr/api/autocomplete/${configId}/`;
         requestData.value = case_sensitive
           ? request.term

--- a/idr_gallery/static/idr_gallery/autocomplete.js
+++ b/idr_gallery/static/idr_gallery/autocomplete.js
@@ -193,9 +193,9 @@ $("#maprQuery")
                     )}:${encodeURI(result.Value)}">
                     ${
                       result["Number of images"]
-                    } Images <span style="color:#bbb">matched</span> ${
+                    } Images <span style="color:#bbb">matched</span> <span class="black">${
                   result.Key
-                }: ${result.Value.replace(queryRegex, "<mark>$&</mark>")}
+                }:</span> ${result.Value.replace(queryRegex, "<mark>$&</mark>")}
                   </a></div>
                   `;
               })
@@ -296,12 +296,15 @@ function getMatchingStudiesHtml(text) {
           .map((kvp) => `<b>${markup(kvp[0])}</b>: ${markup(kvp[1])}`)
           .join("<br>");
 
-      return `<div class="matchingStudy">
-       <div>
-        <a target="_blank" href="${BASE_URL}webclient/?show=${study.objId}">Study ${idrId}</a>
-        (${imgCount})
-        </div><div>${matchingString}</div>
-        </div>`;
+      return `<a target="_blank" href="${BASE_URL}webclient/?show=${study.objId}">
+      <div class="matchingStudy">
+        <div>
+          Study ${idrId} <span class="imgCount">(${imgCount})</span>
+        </div>
+        <div class="matchingString">
+          ${matchingString}
+        </div>
+      </div></a>`;
     })
     .join("\n");
 

--- a/idr_gallery/static/idr_gallery/autocomplete.js
+++ b/idr_gallery/static/idr_gallery/autocomplete.js
@@ -147,6 +147,10 @@ $("#maprQuery")
     source: function (request, response) {
       // if configId is not from mapr, we filter on mapValues...
       let configId = document.getElementById("maprConfig").value;
+      // Don't handle empty queries
+      if (request.term.trim().length == 0) {
+        return;
+      }
 
       if (configId.indexOf("mapr_") != 0 && configId != "any") {
         let matches;
@@ -158,11 +162,6 @@ $("#maprQuery")
           matches = model.getKeyValueAutoComplete(configId, request.term);
         }
         response(matches);
-        return;
-      }
-
-      // Don't handle empty query for mapr
-      if (request.term.length == 0) {
         return;
       }
 
@@ -197,7 +196,7 @@ $("#maprQuery")
           let queryVal = $("#maprQuery").val().trim();
           let results = [];
           // check that input hasn't changed during the call
-          if (configId === "any" && request.term == queryVal) {
+          if (configId === "any" && request.term.trim() == queryVal) {
             autoCompleteDisplayResults(queryVal, data);
           } else {
             results = data;

--- a/idr_gallery/static/idr_gallery/autocomplete.js
+++ b/idr_gallery/static/idr_gallery/autocomplete.js
@@ -103,11 +103,12 @@ $("#maprQuery").on("keyup", function (event) {
 });
 
 function autocompleteSort(queryVal) {
+  queryVal = queryVal.toLowerCase();
   // returns a sort function based on the current query Value
   return (a, b) => {
     // if exact match, show first
-    let aMatch = queryVal == a.Value;
-    let bMatch = queryVal == b.Value;
+    let aMatch = queryVal == a.Value.toLowerCase();
+    let bMatch = queryVal == b.Value.toLowerCase();
     if (aMatch != bMatch) {
       return aMatch ? -1 : 1;
     }

--- a/idr_gallery/static/idr_gallery/categories.js
+++ b/idr_gallery/static/idr_gallery/categories.js
@@ -211,10 +211,14 @@ function render() {
 
 // --------- Render utils -----------
 
-function imageCount(idrId) {
+function imageCount(idrId, container) {
+  // idrId e.g. "idr0001". container optional e.g. "experimentA"
   if (!model.studyStats) return "";
 
   let containers = model.studyStats[idrId];
+  if (container) {
+    containers.filter(c => c.Container == container)
+  }
   if (!containers) return "";
 
   let imgCount = containers

--- a/idr_gallery/static/idr_gallery/categories.js
+++ b/idr_gallery/static/idr_gallery/categories.js
@@ -217,7 +217,7 @@ function imageCount(idrId, container) {
 
   let containers = model.studyStats[idrId];
   if (container) {
-    containers.filter(c => c.Container == container)
+    containers.filter((c) => c.Container == container);
   }
   if (!containers) return "";
 

--- a/idr_gallery/static/idr_gallery/css/search_form_styles.css
+++ b/idr_gallery/static/idr_gallery/css/search_form_styles.css
@@ -63,6 +63,9 @@
   ul.resultsList>li:nth-child(odd) {
     background-color: #ffffff;
   }
+  ul.resultsList>li:hover {
+    background-color: #f4f5f9;
+  }
   .resultsHeader {
     font-weight: bold;
   }
@@ -73,6 +76,7 @@
     display: flex;
     flex-direction: row;
     width: 100%;
+    cursor: pointer;
   }
   .studyColumns div {
     flex: 1;

--- a/idr_gallery/static/idr_gallery/css/search_form_styles.css
+++ b/idr_gallery/static/idr_gallery/css/search_form_styles.css
@@ -115,6 +115,10 @@
     transition: height 0.5s;  /* don't work to max-height */
     overflow-y: auto;
   }
+  .studyImages .loadingMsg {
+    color: #adb4b7;
+    padding: 5px 8px;
+  }
   .expanded .studyImages {
     visibility: visible;
     height: auto;

--- a/idr_gallery/static/idr_gallery/css/search_form_styles.css
+++ b/idr_gallery/static/idr_gallery/css/search_form_styles.css
@@ -126,7 +126,7 @@
     display: inline-block;
     width: 96px;
     height: 96px;
-    margin: 0;
+    margin: 1px;
     padding: 0;
     position: relative;
   }

--- a/idr_gallery/static/idr_gallery/css/search_form_styles.css
+++ b/idr_gallery/static/idr_gallery/css/search_form_styles.css
@@ -1,0 +1,63 @@
+
+.and_clause {
+    border: solid #aaa 1px;
+    padding: 5px;
+    border-radius: 5px;
+    margin: 5px;
+    position: relative;
+    margin-top: 25px;
+  }
+  .and_clause * {
+    box-sizing: border-box;
+  }
+  .and_clause:before {
+    position: absolute;
+    content: "AND";
+    top: -19px;
+    font-size: 14px;
+    left: 0;
+    margin-left: 5px;
+  }
+  .and_clause:first-child {
+    margin-top: 5px;
+  }
+  .and_clause:first-child:before {
+    display: none;
+  }
+  .or_clause {
+    display: flex;
+    align-items: flex-end;
+    -ms-flex-wrap: wrap;
+    flex-wrap: wrap;
+    gap: 5px;
+  }
+  .or_clause > div {
+    flex: 1;
+  }
+  .or_clause:first-child .or {
+    visibility: hidden;
+  }
+  .or_clause label{
+    display: none;
+  }
+  .or_clause:first-child label{
+    display: block;
+  }
+  .or_clause .no_expand,
+  .or_clause .search_condition {
+    flex: 0;
+  }
+  select.condition {
+    width: fit-content;
+  }
+  .and_clause select.keyFields,
+  .and_clause input.valueFields {
+    width: 100%;
+  }
+  
+  /* Results table */
+  
+  .filterColumn {
+    background: transparent;
+    border: none;
+  }

--- a/idr_gallery/static/idr_gallery/css/search_form_styles.css
+++ b/idr_gallery/static/idr_gallery/css/search_form_styles.css
@@ -67,24 +67,28 @@
     font-weight: bold;
   }
   .studyRow {
+    display: block;
+  }
+  .studyColumns {
     display: flex;
     flex-direction: row;
+    width: 100%;
   }
-  .studyRow div {
+  .studyColumns div {
     flex: 1;
     text-align: center;
     padding: 10px;
   }
-  .studyRow .caret {
+  .studyColumns .caret {
     flex: 0 0 50px;
   }
-  .studyRow .studyId {
+  .studyColumns .studyId {
     flex: 0 0 150px;
   }
-  .studyRow .count {
+  .studyColumns .count {
     flex: 0 0 100px;
   }
-  .studyRow .studyName {
+  .studyColumns .studyName {
     flex: 1 0 100px;
   }
 
@@ -96,4 +100,16 @@
 
   .expanded .fa-caret-right {
     transform: rotate(90deg)
+  }
+
+  .studyImages {
+    visibility: hidden;
+    height: 0;
+    transition: height 0.5s;  /* don't work to max-height */
+    overflow-y: auto;
+  }
+  .expanded .studyImages {
+    visibility: visible;
+    height: auto;
+    max-height: 300px;
   }

--- a/idr_gallery/static/idr_gallery/css/search_form_styles.css
+++ b/idr_gallery/static/idr_gallery/css/search_form_styles.css
@@ -1,4 +1,9 @@
 
+/* Hide form elements to simplify */
+.simpleForm #addAND, .simpleForm .addOR, .simpleForm .form-check-label {
+  display: none;
+}
+
 .and_clause {
     border: solid #aaa 1px;
     padding: 5px;
@@ -56,7 +61,9 @@
   }
   
   /* Results list */
-
+  .resultsList {
+    margin-left: 0;
+  }
   ul.resultsList>li:nth-child(even) {
     background-color: #f1f1f1;
   }
@@ -126,6 +133,11 @@
   }
 
   /* Results thumbnails */
+  .studyImages ul {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
   .studyThumb {
     display: inline-block;
     width: 96px;
@@ -133,6 +145,7 @@
     margin: 1px;
     padding: 0;
     position: relative;
+    background-color: #ddd;
   }
   .imgLinks {
     position: absolute;

--- a/idr_gallery/static/idr_gallery/css/search_form_styles.css
+++ b/idr_gallery/static/idr_gallery/css/search_form_styles.css
@@ -57,10 +57,10 @@
   
   /* Results list */
 
-  ul.resultsList li:nth-child(even) {
+  ul.resultsList>li:nth-child(even) {
     background-color: #f1f1f1;
   }
-  ul.resultsList li:nth-child(odd) {
+  ul.resultsList>li:nth-child(odd) {
     background-color: #ffffff;
   }
   .resultsHeader {
@@ -112,4 +112,42 @@
     visibility: visible;
     height: auto;
     max-height: 300px;
+  }
+
+  /* Results thumbnails */
+  .studyThumb {
+    display: inline-block;
+    width: 96px;
+    height: 96px;
+    margin: 0;
+    padding: 0;
+    position: relative;
+  }
+  .imgLinks {
+    position: absolute;
+    background: transparent;
+    visibility: hidden;
+    display: block;
+    z-index: 1;
+    display: flex;
+    flex-direction: row;
+    top: 0;
+    right: 0;
+  }
+  .studyThumb:hover .imgLinks {
+    visibility: visible;
+  }
+  .imgLinks li {
+    display: inline-block;
+    background-color: rgba(255, 255, 255, 0.7);
+    margin: 2px;
+    border-radius: 10px;
+    width: 25px;
+    text-align: center;
+  }
+  .imgLinks a {
+    font-weight: normal;
+    color: rgb(40, 40, 40);
+    width: 100%;
+    display: inline-block;
   }

--- a/idr_gallery/static/idr_gallery/css/search_form_styles.css
+++ b/idr_gallery/static/idr_gallery/css/search_form_styles.css
@@ -94,6 +94,9 @@
   }
   .studyColumns .studyName {
     flex: 1 0 100px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 
   .fa-caret-right {

--- a/idr_gallery/static/idr_gallery/css/search_form_styles.css
+++ b/idr_gallery/static/idr_gallery/css/search_form_styles.css
@@ -61,3 +61,13 @@
     background: transparent;
     border: none;
   }
+
+  .fa-caret-right {
+    font-size: 25px;
+    transition: transform 0.2s;
+    transform-origin: 3px center;
+  }
+
+  .expanded .fa-caret-right {
+    transform: rotate(90deg)
+  }

--- a/idr_gallery/static/idr_gallery/css/search_form_styles.css
+++ b/idr_gallery/static/idr_gallery/css/search_form_styles.css
@@ -55,11 +55,37 @@
     width: 100%;
   }
   
-  /* Results table */
-  
-  .filterColumn {
-    background: transparent;
-    border: none;
+  /* Results list */
+
+  ul.resultsList li:nth-child(even) {
+    background-color: #f1f1f1;
+  }
+  ul.resultsList li:nth-child(odd) {
+    background-color: #ffffff;
+  }
+  .resultsHeader {
+    font-weight: bold;
+  }
+  .studyRow {
+    display: flex;
+    flex-direction: row;
+  }
+  .studyRow div {
+    flex: 1;
+    text-align: center;
+    padding: 10px;
+  }
+  .studyRow .caret {
+    flex: 0 0 50px;
+  }
+  .studyRow .studyId {
+    flex: 0 0 150px;
+  }
+  .studyRow .count {
+    flex: 0 0 100px;
+  }
+  .studyRow .studyName {
+    flex: 1 0 100px;
   }
 
   .fa-caret-right {

--- a/idr_gallery/static/idr_gallery/css/search_form_styles.css
+++ b/idr_gallery/static/idr_gallery/css/search_form_styles.css
@@ -175,3 +175,16 @@
     width: 100%;
     display: inline-block;
   }
+
+  .studyImagesSpinner {
+    text-align: center;
+    color: #ddd;
+    visibility: hidden;
+  }
+  .loading .studyImagesSpinner {
+    visibility: visible;
+  }
+  .studyImagesSpinner svg {
+    width: 50px;
+    margin: 10px;
+  }

--- a/idr_gallery/static/idr_gallery/model.js
+++ b/idr_gallery/static/idr_gallery/model.js
@@ -14,6 +14,11 @@
 //   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // NB: SOURCE FILES are under /src. Compiled files are under /static/
 
+function escapeRegExp(string) {
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#escaping
+  return string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"); // $& means the whole matched string
+}
+
 class StudiesModel {
   constructor() {
     this.base_url = BASE_URL;
@@ -380,12 +385,8 @@ class StudiesModel {
 
     // We don't split words to provide 'AND' functionality (since it's not supported for Images)
     // let regexes = text.split(" ").map((token) => new RegExp(token, "i"));
-    let regexes = [new RegExp(text, "i")];
+    let regex = new RegExp(escapeRegExp(text), "i");
 
-    function matchSome(kvp) {
-      return regexes.some((re) => re.test(kvp[1]));
-    }
-    const re = new RegExp(text, "i");
     return this.studies
       .map((study) => {
         // we want ALL the search tokens to match at least somewhere in kvp or Description
@@ -394,13 +395,11 @@ class StudiesModel {
           keyValuePairs = [...study.mapValues];
         }
         keyValuePairs.push(["Description", study.StudyDescription]);
-        let match = regexes.every((re) =>
-          keyValuePairs.some((kvp) => re.test(kvp[1]))
-        );
+        let match = keyValuePairs.some((kvp) => regex.test(kvp[1]));
         if (!match) return;
 
         // return [study, "key: value string showing matching text"]
-        let matches = keyValuePairs.filter(matchSome);
+        let matches = keyValuePairs.filter((kvp) => regex.test(kvp[1]));
         return [study, matches];
       })
       .filter(Boolean);

--- a/idr_gallery/static/idr_gallery/model.js
+++ b/idr_gallery/static/idr_gallery/model.js
@@ -377,7 +377,11 @@ class StudiesModel {
     // Search for studies with text in their keys, values, or description.
     // Returns a list of matching studies. Each study is returned along with kvps that matches text
     // [study, [{key: value}, {Description: this study is great}]]
-    let regexes = text.split(" ").map((token) => new RegExp(token, "i"));
+
+    // We don't split words to provide 'AND' functionality (since it's not supported for Images)
+    // let regexes = text.split(" ").map((token) => new RegExp(token, "i"));
+    let regexes = [new RegExp(text, "i")];
+
     function matchSome(kvp) {
       return regexes.some((re) => re.test(kvp[1]));
     }

--- a/idr_gallery/static/idr_gallery/model.js
+++ b/idr_gallery/static/idr_gallery/model.js
@@ -380,7 +380,7 @@ class StudiesModel {
 
   filterStudiesAnyText(text) {
     // Search for studies with text in their keys, values, or description.
-    // Returns a list of matching studies. Each study is returned along with kvps that matches text
+    // Returns a list of matching studies. Each study is returned along with kvps that match text
     // [study, [{key: value}, {Description: this study is great}]]
 
     // We don't split words to provide 'AND' functionality (since it's not supported for Images)

--- a/idr_gallery/static/idr_gallery/omero_search_form.js
+++ b/idr_gallery/static/idr_gallery/omero_search_form.js
@@ -474,9 +474,18 @@ class OmeroSearchForm {
     return query;
   }
 
+  getPreviousSearchQuery() {
+    // deep copy
+    return JSON.parse(JSON.stringify(this.previousSearchQuery));
+  }
+  setPreviousSearchQuery(query) {
+    this.previousSearchQuery = query;
+  }
+
   submitSearch() {
     let query = this.getCurrentQuery();
     query = this.modifyQueryCellTissue(query);
+    this.setPreviousSearchQuery(query);
     let self = this;
     this.$results.empty();
     this.showSpinner();
@@ -625,8 +634,8 @@ class OmeroSearchForm {
         }
         $studyRow.toggleClass("expanded");
 
-        // Load study images...
-        let query = this.getCurrentQuery();
+        // Load study images, using previous query as basis
+        let query = this.getPreviousSearchQuery();
         let self = this;
         query.query_details.and_filters.push({
           name: "Name (IDR number)",

--- a/idr_gallery/static/idr_gallery/omero_search_form.js
+++ b/idr_gallery/static/idr_gallery/omero_search_form.js
@@ -177,6 +177,33 @@ class OmeroSearchForm {
     return query;
   }
 
+  getHumanReadableQuery() {
+    // E.g. "Antibody equals seh1-fl antibody AND (Gene Symbol equals cdc42 OR Gene Symbol equals cdc25c)"
+    let query = this.getCurrentQuery();
+    // name, value, operator, resource
+    let andQuery = query.query_details.and_filters.map(q => `${q.name} ${q.operator} ${q.value}`).join(" AND ");
+    let orQueries = query.query_details.or_filters.map(ors => {
+      return "(" + ors.map(q => `${q.name} ${q.operator} ${q.value}`).join(" OR ") + ")";
+    });
+    let results = [];
+    if (andQuery.length > 0) {
+      results.push(andQuery);
+    }
+    if (orQueries.length > 0) {
+      results.push(orQueries);
+    }
+    return results.join(" AND ");
+  }
+
+  setAdvanced(advanced) {
+    // show/hide advanced search buttons "AND" and "OR" for creating advanced searches
+    if (advanced) {
+      this.$form.removeClass("simpleForm");
+    } else {
+      this.$form.addClass("simpleForm");
+    }
+  }
+
   setKeyValues($orClause) {
     // Adds <option> to '.keyFields' for each item in pre-cached resources_data
     let $field = $(".keyFields", $orClause);

--- a/idr_gallery/static/idr_gallery/omero_search_form.js
+++ b/idr_gallery/static/idr_gallery/omero_search_form.js
@@ -183,7 +183,10 @@ class OmeroSearchForm {
     let query = this.getCurrentQuery();
     // name, value, operator, resource
     let andQuery = query.query_details.and_filters
-      .map((q) => `${q.name} ${q.operator} ${q.value}`)
+      .map(
+        (q) =>
+          `<strong>${q.name}</strong> ${q.operator} <strong>${q.value}</strong>`
+      )
       .join(" AND ");
     let orQueries = query.query_details.or_filters.map((ors) => {
       return (

--- a/idr_gallery/static/idr_gallery/omero_search_form.js
+++ b/idr_gallery/static/idr_gallery/omero_search_form.js
@@ -273,7 +273,7 @@ class OmeroSearchForm {
           let data = { value: request.term };
           let url = `${SEARCH_ENGINE_URL}resources/image/searchvalues/`;
           if (key != "Any") {
-            url = url += `&key=${encodeURI(key)}`;
+            data.key=key;
           }
           // showSpinner();
           $.ajax({

--- a/idr_gallery/static/idr_gallery/omero_search_form.js
+++ b/idr_gallery/static/idr_gallery/omero_search_form.js
@@ -354,7 +354,6 @@ class OmeroSearchForm {
   }
 
   setKeyValueQuery(query) {
-    let { key, value } = query;
     // Clear form and create new...
     $(".clauses", this.$form).empty();
     this.addAnd(query);
@@ -387,7 +386,7 @@ class OmeroSearchForm {
   }
 
   addAnd(query) {
-    // query is e.g. {key: "Antibody", value: "foo"}
+    // query is e.g. {key: "Antibody", value: "foo", operator?: "equals"}
     let $andClause = $(AND_CLAUSE_HTML);
     $(".clauses", this.$form).append($andClause);
 
@@ -396,9 +395,9 @@ class OmeroSearchForm {
     this.setKeyValues($andClause);
 
     console.log("addAnd", query);
-    if (query?.name) {
+    if (query?.key) {
       // add <option> if not there
-      this.setKeyField($andClause, query.name);
+      this.setKeyField($andClause, query.key);
     }
     if (query?.value) {
       $(".valueFields", $andClause).val(query.value);

--- a/idr_gallery/static/idr_gallery/omero_search_form.js
+++ b/idr_gallery/static/idr_gallery/omero_search_form.js
@@ -491,7 +491,7 @@ class OmeroSearchForm {
     this.showSpinner();
     $.ajax({
       type: "POST",
-      url: SEARCH_ENGINE_URL + "resources/submitquery_returnstudies/",
+      url: SEARCH_ENGINE_URL + "resources/submitquery/containers/",
       contentType: "application/json;charset=UTF-8",
       dataType: "json",
       data: JSON.stringify(query),
@@ -532,10 +532,16 @@ class OmeroSearchForm {
       return a["image count"] > b["image count"] ? -1 : 1;
     });
 
+    function getValue(keyvals, key) {
+      let kvp = keyvals.find(kv => kv.key == key);
+      return kvp?.value;
+    }
+
     let resultsList = studyList
       .map((row) => {
-        let studyName = row["Name (IDR number)"];
-        let title = row["title"];
+        let studyName = row["name"];
+        let keyVals = row["key_values"];
+        let title = getValue(keyVals, "Publication Title") || getValue(keyVals, "Study Title") || studyName;
         let objId = row["id"];
         let objType = row["type"];
         let tokens = studyName.split("-");

--- a/idr_gallery/static/idr_gallery/omero_search_form.js
+++ b/idr_gallery/static/idr_gallery/omero_search_form.js
@@ -481,7 +481,7 @@ class OmeroSearchForm {
           </ul>
         </li>`;
       })
-      .join("\n");
+      .join("");
     $(".studyImages", $studyRow).html(`<ul>${html}</ul>`);
   }
 

--- a/idr_gallery/static/idr_gallery/omero_search_form.js
+++ b/idr_gallery/static/idr_gallery/omero_search_form.js
@@ -1,0 +1,479 @@
+const AND_CLAUSE_HTML = `
+<div class="and_clause">
+  <div class="or_clause">
+    <div class="or no_expand">OR</div>
+    <div class="search_key">
+        <label for="keyFields">Attribute</label>
+        <select id="keyFields" class="form-control keyFields">
+        </select>
+    </div>
+    <div class="search_condition">
+        <label for="condition">Operator</label>
+        <select id="condition" class="form-control condition">
+          <option value="equals">equals</option>
+          <option value="not_equals">not equals</option>
+          <option value="contains">contains</option>
+          <option value="not_contains">not contains</option>
+        </select>
+    </div>
+    <div class="search_value" style="position: relative">
+        <label for="valueFields">Value</label>
+        <input type="text" class="form-control valueFields" id="valueFields" placeholder="type the attribute value">
+    </div>
+    <div class="no_expand">
+        <button class="remove_row btn btn-sm btn-outline-danger">
+          X
+        </button>
+    </div>
+  </div>
+  <button class="addOR" href="#" title="Add OR condition to the group">
+    add 'OR'...
+  </button>
+</div>`;
+
+const FORM_FOOTER_HTML = `
+<div>
+<button id="addAND" type="button" class="no-border" title="Add an 'AND' clause to the query">
+  add AND...
+</button>
+<label class="form-check-label" for="case_sensitive">
+  Case sensitive:
+  <input class="form-check-input" type="checkbox" value="" id="case_sensitive" />
+</label>
+<button type="submit">Search</button>
+</div>
+`;
+
+// <?xml version="1.0" encoding="iso-8859-1"?>
+// <!-- Generator: Adobe Illustrator 18.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+// <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+const FILTER_ICON_SVG = `
+<svg width="16px" height="16px" version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 210.68 210.68" style="enable-background:new 0 0 210.68 210.68;" xml:space="preserve">
+<path d="M205.613,30.693c0-10.405-10.746-18.149-32.854-23.676C154.659,2.492,130.716,0,105.34,0
+	C79.965,0,56.021,2.492,37.921,7.017C15.813,12.544,5.066,20.288,5.066,30.693c0,3.85,1.476,7.335,4.45,10.479l68.245,82.777v79.23
+	c0,2.595,1.341,5.005,3.546,6.373c1.207,0.749,2.578,1.127,3.954,1.127c1.138,0,2.278-0.259,3.331-0.78l40.075-19.863
+	c2.55-1.264,4.165-3.863,4.169-6.71l0.077-59.372l68.254-82.787C204.139,38.024,205.613,34.542,205.613,30.693z M44.94,20.767
+	C61.467,17.048,82.917,15,105.34,15s43.874,2.048,60.399,5.767c18.25,4.107,23.38,8.521,24.607,9.926
+	c-1.228,1.405-6.357,5.819-24.607,9.926c-16.525,3.719-37.977,5.767-60.399,5.767S61.467,44.338,44.94,40.62
+	c-18.249-4.107-23.38-8.521-24.607-9.926C21.56,29.288,26.691,24.874,44.94,20.767z M119.631,116.486
+	c-1.105,1.341-1.711,3.023-1.713,4.761l-0.075,57.413l-25.081,12.432v-69.835c0-1.741-0.605-3.428-1.713-4.771L40.306,54.938
+	C58.1,59.1,81.058,61.387,105.34,61.387c24.283,0,47.24-2.287,65.034-6.449L119.631,116.486z"/>
+</svg>`
+
+class OmeroSearchForm {
+  constructor(formId, SEARCH_ENGINE_URL, tableId) {
+    this.SEARCH_ENGINE_URL = SEARCH_ENGINE_URL;
+    this.resources_data = {};
+    this.query_mode = "searchterms";
+    this.cached_key_values = {};
+    this.autoCompleteCache = {};
+
+    // build form
+    this.formId = formId;
+    this.$form = $(`#${formId}`);
+    this.$form.html(`<div class="clauses"></div>`);
+    this.$form.append($(FORM_FOOTER_HTML));
+
+    // If tableId, create table element...
+    if (tableId) {
+      this.$table = $(`#${tableId}`);
+    }
+
+    this.buttonHandlers();
+    this.pubsub = $({});
+
+    // TODO: wait for loadResources()
+    // then build form...
+    (async function() {
+      await this.loadResources();
+      this.addAnd();
+      this.trigger("ready");
+    }.bind(this))()
+  }
+
+  // pub/sub methods. see https://github.com/cowboy/jquery-tiny-pubsub
+  on() {
+    let o = this.pubsub;
+    o.on.apply(o, arguments);
+  }
+
+  off() {
+    let o = this.pubsub;
+    o.off.apply(o, arguments);
+  }
+
+  trigger() {
+    let o = this.pubsub;
+    o.trigger.apply(o, arguments);
+  }
+
+  async loadResources(mode = "searchterms") {
+    let url;
+    if (mode == "advanced") {
+      url = this.SEARCH_ENGINE_URL + "resources/all/keys/";
+    } else {
+      url = this.SEARCH_ENGINE_URL + "resources/all/keys/";
+      url = url + "?mode=" + encodeURIComponent(mode);
+    }
+    this.resources_data = await fetch(url).then((response) => response.json());
+    if (this.resources_data.error != undefined) {
+      alert(this.resources_data.error);
+    }
+
+    return this.resources_data;
+  }
+
+  findResourceForKey(key) {
+    // e.g. find if 'Antibody' key comes from 'image', 'project' etc
+    for (let resource in this.resources_data) {
+      if (this.resources_data[resource].includes(key)) {
+        return resource;
+      }
+    }
+    // Not found: e.g. this.resources_data only has common 'searchterms'
+    // assume 'image'...
+    return 'image';
+  }
+
+  getCurrentQuery() {
+    let form_id = this.formId;
+    let and_conditions = [];
+    let or_conditions = [];
+
+    let queryandnodes = document.querySelectorAll(`#${form_id} .and_clause`);
+    for (let i = 0; i < queryandnodes.length; i++) {
+      let node = queryandnodes[i];
+      // handle each OR...
+      let ors = node.querySelectorAll(".or_clause");
+
+      let or_dicts = [...ors].map((orNode) => {
+        return {
+          name: orNode.querySelector(".keyFields").value,
+          value: orNode.querySelector(".valueFields").value,
+          operator: orNode.querySelector(".condition").value,
+          resource: this.findResourceForKey(
+            orNode.querySelector(".keyFields").value
+          ),
+        };
+      });
+      if (or_dicts.length > 1) {
+        or_conditions.push(or_dicts);
+      } else {
+        and_conditions.push(or_dicts[0]);
+      }
+    }
+
+    let query_details = {};
+    var query = {
+      resource: "image",
+      query_details: query_details,
+    };
+
+    query_details["and_filters"] = and_conditions;
+    query_details["or_filters"] = or_conditions;
+    query_details["case_sensitive"] =
+      document.getElementById("case_sensitive").checked;
+    query["mode"] = this.query_mode;
+    return query;
+  }
+
+  setKeyValues($orClause) {
+    // Adds <option> to '.keyFields' for each item in pre-cached resources_data
+    let $field = $(".keyFields", $orClause);
+    let anyOption = `<option value="Any">Any</option>`;
+    let html = Object.entries(this.resources_data)
+      .map((keyValues) => {
+        keyValues[1].sort();
+        return keyValues[1]
+          .map((value) => `<option value="${value}">${value}</option>`)
+          .join("\n");
+      })
+      .join("\n");
+    $field.html(anyOption + html);
+  }
+
+  initAutoComplete($orClause) {
+    let self = this;
+    let $this = $(".valueFields", $orClause);
+    // key is updated when user starts typing, also used to handle response and select
+    let key;
+    $this
+      .autocomplete({
+        autoFocus: false,
+        delay: 1000,
+        source: function (request, response) {
+          // Need to know what Attribute is of adjacent <select>
+          key = $(".keyFields", $orClause).val();
+          console.log("key...", key);
+          let url = `${SEARCH_ENGINE_URL}resources/image/getannotationvalueskey/?key=${encodeURI(
+            key
+          )}&resource=image`;
+
+          // If possible values for current Key are cached...
+          if (self.autoCompleteCache[key]) {
+            let input = request.term.toLowerCase();
+            let results = self.autoCompleteCache[key].filter((term) =>
+              term.toLowerCase().includes(input)
+            );
+            response(results);
+            return;
+          }
+          // ...otherwise we need AJAX call...
+          // 'Any' uses different query
+          if (key == "Any") {
+            url = `${SEARCH_ENGINE_URL}resources/image/searchvalues/?value=${encodeURI(
+              request.term
+            )}&resource=image`;
+          }
+          // showSpinner();
+          $.ajax({
+            dataType: "json",
+            type: "GET",
+            url: url,
+            success: function (data) {
+              // hideSpinner();
+              console.log(data);
+              let results = [{ label: "No results found.", value: -1 }];
+              if (key == "Any" && data.data.length > 0) {
+                // only try to show top 100 items...
+                let max_shown = 100;
+                let result_count = data.data.length;
+                results = data.data.slice(0, 100).map((result) => {
+                  return {
+                    key: result.Key,
+                    label: `<b>${result.Value}</b> (${result.Key}) <span style="color:#bbb">${result["Number of images"]}</span>`,
+                    value: `${result.Value}`,
+                  };
+                });
+                if (result_count > max_shown) {
+                  results.push({
+                    key: -1, label: `...and ${result_count - max_shown} more matches not shown`, value: -1
+                  });
+                }
+              } else {
+                // cache for future use
+                self.autoCompleteCache[key] = data;
+                // We need to filter by input text
+                let input = request.term.toLowerCase();
+                results = data.filter((term) =>
+                  term.toLowerCase().includes(input)
+                );
+              }
+              response(results);
+            },
+            error: function (data) {
+              console.log("ERROR", data);
+              // hideSpinner();
+              response([{ label: "Failed to load", value: -1 }]);
+            },
+          });
+        },
+        minLength: 3,
+        open: function () {},
+        close: function () {
+          // $(this).val('');
+          return false;
+        },
+        focus: function (event, ui) {},
+        select: function (event, ui) {
+          console.log("select", ui.item, key == "Any");
+          if (ui.item.value == -1) {
+            // Ignore 'No results found'
+            return false;
+          }
+          if (key == "Any") {
+            // Use 'key' to update KeyField
+            self.setKeyField($orClause, ui.item.key);
+          }
+          return true;
+        },
+      })
+      .data("ui-autocomplete")._renderItem = function (ul, item) {
+      return $("<li>")
+        .append("<a style='font-size:14px; width:245px'>" + item.label + "</a>")
+        .appendTo(ul);
+    };
+  }
+
+  setKeyField($parent, key) {
+    // Adds the Key as an <option> to the <select> if not there;
+    let $select = $(".keyFields", $parent);
+    if ($(`option[value='${key}']`, $select).length == 0) {
+      $select.append($(`<option value="${key}">${key}</option>`));
+    }
+    $select.val(key);
+  }
+
+  displayHideRemoveButtons() {
+    let $btns = $(".remove_row", this.$form);
+    $btns.each(function (index, btn) {
+      if ($btns.length == 1) {
+        $(btn).css("visibility", "hidden");
+      } else {
+        $(btn).css("visibility", "visible");
+      }
+    });
+  }
+
+  setQuery(query) {
+    let {key, value} = query;
+    // Clear form and create new...
+    $(".clauses", this.$form).empty();
+    this.addAnd(query);
+  }
+
+  addAnd(query) {
+    // query is e.g. {key: "Antibody", value: "foo"}
+    let $andClause = $(AND_CLAUSE_HTML);
+    $(".clauses", this.$form).append($andClause);
+
+    // auto-complete (for the first row in the form)
+    this.initAutoComplete($andClause);
+    this.setKeyValues($andClause);
+
+    console.log("addAnd", query);
+    if (query?.key) {
+      // add <option> if not there
+      this.setKeyField($andClause, query.key)
+    }
+    if (query?.value) {
+      $(".valueFields", $andClause).val(query.value);
+    }
+
+    this.displayHideRemoveButtons();
+  }
+
+  addOr($andClause) {
+    let $orClause = $(".or_clause", $andClause).last().clone();
+    // Clone the last '.or_clause' and insert it before the ".addOR" button
+    $(".addOR", $andClause).before($orClause);
+    // init auto-complete for ALL 'or' rows (re-init for existing rows)
+    this.initAutoComplete($orClause);
+    this.displayHideRemoveButtons();
+  }
+
+  removeOr($orClause) {
+    let $andClause = $orClause.closest(".and_clause");
+    $orClause.remove();
+    // Remove parent 'and_clause' if it has no other 'or_clause'
+    if ($(".or_clause", $andClause).length === 0) {
+      $andClause.remove();
+    }
+    this.displayHideRemoveButtons();
+  }
+
+  submitSearch() {
+    let query = this.getCurrentQuery();
+    let self = this;
+    console.log(query);
+    $.ajax({
+      type: "POST",
+      url: SEARCH_ENGINE_URL + "resources/submitquery/?return_columns=True",
+      contentType: "application/json;charset=UTF-8",
+      dataType: "json",
+      data: JSON.stringify(query),
+      success: function (data) {
+        if (data["Error"] != "none") {
+          alert(data["Error"]);
+          return;
+        }
+        // publish results to subscribers
+        self.trigger("results", data);
+        // can display in table if specified
+        if (self.$table) {
+          self.displayResults(data);
+        }
+      },
+      error: function (XMLHttpRequest, textStatus, errorThrown) {
+        alert("Status: " + textStatus);
+        alert("Error: " + errorThrown);
+      },
+    });
+  }
+
+  displayResults(data) {
+    console.log("displayResults", data);
+    // TODO: check how errors are handled
+    // if (data.Error && data.Error != "none") {
+    //     $("#dataTable").html(`<tr><td>${data.Error}</td></tr>`);
+    //     return;
+    // }
+
+    // FIXME:
+    let webindex = "https://idr.openmicroscopy.org/webclient/"   // WEBCLIENT.URLS.webindex;
+    let thumbUrl = webindex + "render_thumbnail/";
+    let showFilterIcon = true;
+
+    let results_array = data?.values;
+    if (!results_array) {
+        alert("No results");
+    }
+
+    // Most columns are the names of Keys
+    let keyColumnNames = data.columns.map(col => col.field);
+    // Full list includes Id, Name, Study name...
+    let columnNames = data.columns_def.map(col => col.field);
+
+    let thead = `<th>${new Intl.NumberFormat().format(data.size)} Images</th>`;
+    // thead += ["Name", "Study_name"].map(col => `<th>${col}</th>`).join("");
+    thead += columnNames.map(col => `<th>
+        ${ showFilterIcon && keyColumnNames.includes(col) ?
+          `<button title="Filter by ${col}" class="filterColumn" data-colname="${col}">
+            ${FILTER_ICON_SVG}
+        </button>` : ''}
+        ${col}</th>`).join("");
+    thead += "<th></th>";
+    let tbody = data.values.slice(0,100).map(row => {
+        let thumb = `<td><img loading="lazy" src="${thumbUrl}${ row.Id }/" /></td>`;
+        let tds = columnNames.map(col => `<td>${row[col] ? row[col] : ""}</td>`).join("");
+        let browse = `<td class="browse"><a target="_blank" title="Open this Image in another tab" href="${webindex}?show=image-${ row.Id }">Browse</a></td>`;
+        // let tds = row.key_values.map(kv => `<td>${kv.value}</td>`).join("");
+        return `<tr id="image-${ row.Id }">${thumb}${ tds }${browse}</tr>`;
+    }).join('\n');
+
+    let table = `
+        <thead>${thead}</thead>
+        <tbody>${tbody}</tbody>
+    `
+    if (this.$table) {
+      this.$table.html(table);
+    }
+  }
+
+  // Set-up event handlers on Buttons
+  buttonHandlers() {
+    $("#addAND").on("click", event => {
+      event.preventDefault();
+      this.addAnd()
+    });
+
+    this.$form.on("click", ".addOR", event => {
+      event.preventDefault();
+      let $andClause = $(event.target).closest(".and_clause");
+      this.addOr($andClause);
+    });
+
+    this.$form.on("click", ".remove_row", event => {
+      event.preventDefault();
+      let $orClause = $(event.target).closest(".or_clause");
+      this.removeOr($orClause);
+    });
+
+    $("button[type='submit']", this.$form).on("click", event => {
+      event.preventDefault();
+      this.submitSearch();
+    });
+
+    // table - filter button adds an AND filter
+    if (this.$table) {
+      $(this.$table).on("click", ".filterColumn", event => {
+        event.preventDefault();
+        // handle click in svg element within the button
+        let $button = $(event.target).closest(".filterColumn");
+        let colName = $button.data("colname");
+        this.addAnd({key: colName});
+      });
+    }
+  }
+}

--- a/idr_gallery/static/idr_gallery/omero_search_form.js
+++ b/idr_gallery/static/idr_gallery/omero_search_form.js
@@ -432,7 +432,7 @@ class OmeroSearchForm {
       <div class="studyColumns">
         <div class="caret"></i></div>
         <div class="studyId">Study ID</div>
-        <div class="count">count?</div>
+        <div class="count">Images</div>
         <div class="studyName">Title</div>
       </div>
     </li>`;
@@ -440,14 +440,16 @@ class OmeroSearchForm {
     let resultsList = studyList
       .map((row) => {
         let studyName = row["Name (IDR number)"];
+        let title = row["title"];
         let tokens = studyName.split("-");
         let studyId = tokens[0] + studyName.slice(studyName.length - 1);
+        let count = row["image count"];
         return `<li class="studyRow" data-name="${studyName}">
             <div class="studyColumns">
                 <div class="caret"><i class="fa fa-caret-right"></i></div>
                 <div class="studyId">${studyId}</div>
-                <div class="count">count?</div>
-                <div class="studyName">${studyName}</div>
+                <div class="count">${count}</div>
+                <div class="studyName">${title}</div>
             </div>
             <div class="studyImages">Loading images...</div>
         </li>`;

--- a/idr_gallery/static/idr_gallery/omero_search_form.js
+++ b/idr_gallery/static/idr_gallery/omero_search_form.js
@@ -619,7 +619,7 @@ class OmeroSearchForm {
           alert(data["Error"]);
           return;
         }
-        let {page, total_pages, bookmark} = data.results;
+        let { page, total_pages, bookmark } = data.results;
         if (bookmark && page < total_pages) {
           $studyRow.data("bookmark", data.results.bookmark);
         } else {

--- a/idr_gallery/static/idr_gallery/omero_search_form.js
+++ b/idr_gallery/static/idr_gallery/omero_search_form.js
@@ -273,7 +273,7 @@ class OmeroSearchForm {
           let data = { value: request.term };
           let url = `${SEARCH_ENGINE_URL}resources/image/searchvalues/`;
           if (key != "Any") {
-            data.key=key;
+            data.key = key;
           }
           // showSpinner();
           $.ajax({
@@ -648,7 +648,7 @@ class OmeroSearchForm {
     const bookmark = data.results.bookmark;
     let html = imageList
       .map((img) => {
-        // Each humbnail links to image viewer. Hover menu links to viewer (eye) and webclient (i)
+        // Each thumbnail links to image viewer. Hover menu links to viewer (eye) and webclient (i)
         return `<li class="studyThumb">
           <a target="_blank" href="${BASE_URL}webclient/img_detail/${img.id}">
             <img title="${img.name}" src="${BASE_URL}webclient/render_thumbnail/${img.id}/" loading="lazy" />

--- a/idr_gallery/static/idr_gallery/omero_search_form.js
+++ b/idr_gallery/static/idr_gallery/omero_search_form.js
@@ -62,7 +62,7 @@ const FILTER_ICON_SVG = `
 </svg>`;
 
 class OmeroSearchForm {
-  constructor(formId, SEARCH_ENGINE_URL, tableId) {
+  constructor(formId, SEARCH_ENGINE_URL, resultsId) {
     this.SEARCH_ENGINE_URL = SEARCH_ENGINE_URL;
     this.resources_data = {};
     this.query_mode = "searchterms";
@@ -75,9 +75,9 @@ class OmeroSearchForm {
     this.$form.html(`<div class="clauses"></div>`);
     this.$form.append($(FORM_FOOTER_HTML));
 
-    // If tableId, create table element...
-    if (tableId) {
-      this.$table = $(`#${tableId}`);
+    // If resultsId, create results element...
+    if (resultsId) {
+      this.$results = $(`#${resultsId}`);
     }
 
     this.buttonHandlers();
@@ -387,7 +387,7 @@ class OmeroSearchForm {
         // publish results to subscribers
         self.trigger("results", data);
         // can display in table if specified
-        if (self.$table) {
+        if (self.$results) {
           self.displayResults(data);
         }
       },
@@ -413,29 +413,29 @@ class OmeroSearchForm {
         alert("No results");
     }
 
-    let thead = `<tr><th></th><th>Study ID</th>`;
-    thead += `<th>Count</th><th>Title</th></tr>`;
+    let thead = `<li class="studyRow resultsHeader">
+        <div class="caret"></i></div>
+        <div class="studyId">Study ID</div>
+        <div class="count">count?</div>
+        <div class="studyName">Title</div>
+    </li>`;
 
-    let tbody = studyList
+    let resultsList = studyList
       .map((row) => {
         let studyName = row["Name (IDR number)"];
         let tokens = studyName.split("-");
         let studyId = tokens[0] + studyName.slice(studyName.length-1);
-        return `<tr class="studyRow" data-name="${studyName}">
-            <td><i class="fa fa-caret-right"></i></td>
-            <td>${studyId}</td>
-            <td>count?</td>
-            <td>${studyName}</td>
-        </tr>`;
+        return `<li class="studyRow" data-name="${studyName}">
+            <div class="caret"><i class="fa fa-caret-right"></i></div>
+            <div class="studyId">${studyId}</div>
+            <div class="count">count?</div>
+            <div class="studyName">${studyName}</div>
+        </li>`;
       })
       .join("\n");
 
-    let table = `
-        <thead>${thead}</thead>
-        <tbody>${tbody}</tbody>
-    `;
-    if (this.$table) {
-      this.$table.html(table);
+    if (this.$results) {
+      this.$results.html(thead + resultsList);
     }
   }
 
@@ -464,16 +464,16 @@ class OmeroSearchForm {
     });
 
     // table - filter button adds an AND filter
-    if (this.$table) {
+    if (this.$results) {
 
-    //   $(this.$table).on("click", ".filterColumn", (event) => {
+    //   $(this.$results).on("click", ".filterColumn", (event) => {
     //     event.preventDefault();
     //     // handle click in svg element within the button
     //     let $button = $(event.target).closest(".filterColumn");
     //     let colName = $button.data("colname");
     //     this.addAnd({ key: colName });
     //   });
-        $(this.$table).on("click", ".studyRow", (event) => {
+        $(this.$results).on("click", ".studyRow", (event) => {
             console.log("studyRow click", event.target, event.target.nodeName);
             // ignore click on links...
             if (event.target.nodeName == 'A') return;

--- a/idr_gallery/static/idr_gallery/omero_search_form.js
+++ b/idr_gallery/static/idr_gallery/omero_search_form.js
@@ -500,7 +500,7 @@ class OmeroSearchForm {
         <div class="caret"></i></div>
         <div class="studyId">Study ID</div>
         <div class="count">Images</div>
-        <div class="studyName">Title</div>
+        <div class="studyName">Publication Title</div>
       </div>
     </li>`;
 

--- a/idr_gallery/static/idr_gallery/omero_search_form.js
+++ b/idr_gallery/static/idr_gallery/omero_search_form.js
@@ -265,7 +265,7 @@ class OmeroSearchForm {
     let key;
     $this
       .autocomplete({
-        autoFocus: false,
+        autoFocus: true,
         delay: 1000,
         source: function (request, response) {
           // Need to know what Attribute is of adjacent <select>

--- a/idr_gallery/static/idr_gallery/omero_search_form.js
+++ b/idr_gallery/static/idr_gallery/omero_search_form.js
@@ -59,7 +59,7 @@ const FILTER_ICON_SVG = `
 	c-18.249-4.107-23.38-8.521-24.607-9.926C21.56,29.288,26.691,24.874,44.94,20.767z M119.631,116.486
 	c-1.105,1.341-1.711,3.023-1.713,4.761l-0.075,57.413l-25.081,12.432v-69.835c0-1.741-0.605-3.428-1.713-4.771L40.306,54.938
 	C58.1,59.1,81.058,61.387,105.34,61.387c24.283,0,47.24-2.287,65.034-6.449L119.631,116.486z"/>
-</svg>`
+</svg>`;
 
 class OmeroSearchForm {
   constructor(formId, SEARCH_ENGINE_URL, tableId) {
@@ -85,11 +85,11 @@ class OmeroSearchForm {
 
     // TODO: wait for loadResources()
     // then build form...
-    (async function() {
+    (async function () {
       await this.loadResources();
       this.addAnd();
       this.trigger("ready");
-    }.bind(this))()
+    }.bind(this)());
   }
 
   // pub/sub methods. see https://github.com/cowboy/jquery-tiny-pubsub
@@ -133,7 +133,7 @@ class OmeroSearchForm {
     }
     // Not found: e.g. this.resources_data only has common 'searchterms'
     // assume 'image'...
-    return 'image';
+    return "image";
   }
 
   getCurrentQuery() {
@@ -248,7 +248,11 @@ class OmeroSearchForm {
                 });
                 if (result_count > max_shown) {
                   results.push({
-                    key: -1, label: `...and ${result_count - max_shown} more matches not shown`, value: -1
+                    key: -1,
+                    label: `...and ${
+                      result_count - max_shown
+                    } more matches not shown`,
+                    value: -1,
                   });
                 }
               } else {
@@ -317,7 +321,7 @@ class OmeroSearchForm {
   }
 
   setQuery(query) {
-    let {key, value} = query;
+    let { key, value } = query;
     // Clear form and create new...
     $(".clauses", this.$form).empty();
     this.addAnd(query);
@@ -335,7 +339,7 @@ class OmeroSearchForm {
     console.log("addAnd", query);
     if (query?.key) {
       // add <option> if not there
-      this.setKeyField($andClause, query.key)
+      this.setKeyField($andClause, query.key);
     }
     if (query?.value) {
       $(".valueFields", $andClause).val(query.value);
@@ -369,7 +373,9 @@ class OmeroSearchForm {
     console.log(query);
     $.ajax({
       type: "POST",
-      url: SEARCH_ENGINE_URL + "resources/submitquery/?return_columns=True",
+      url:
+        SEARCH_ENGINE_URL +
+        "resources/submitquery_returnstudies/",
       contentType: "application/json;charset=UTF-8",
       dataType: "json",
       data: JSON.stringify(query),
@@ -400,42 +406,29 @@ class OmeroSearchForm {
     //     return;
     // }
 
-    // FIXME:
-    let webindex = "https://idr.openmicroscopy.org/webclient/"   // WEBCLIENT.URLS.webindex;
-    let thumbUrl = webindex + "render_thumbnail/";
-    let showFilterIcon = true;
+    let studyList = data.results.results;
 
-    let results_array = data?.values;
-    if (!results_array) {
+    if (studyList.length == 0) {
         alert("No results");
     }
 
-    // Most columns are the names of Keys
-    let keyColumnNames = data.columns.map(col => col.field);
-    // Full list includes Id, Name, Study name...
-    let columnNames = data.columns_def.map(col => col.field);
+    let thead = `<tr><th>${new Intl.NumberFormat().format(studyList.length)} Studies</th>`;
+    thead += `<th>Count</th><th>Title</th></tr>`;
 
-    let thead = `<th>${new Intl.NumberFormat().format(data.size)} Images</th>`;
-    // thead += ["Name", "Study_name"].map(col => `<th>${col}</th>`).join("");
-    thead += columnNames.map(col => `<th>
-        ${ showFilterIcon && keyColumnNames.includes(col) ?
-          `<button title="Filter by ${col}" class="filterColumn" data-colname="${col}">
-            ${FILTER_ICON_SVG}
-        </button>` : ''}
-        ${col}</th>`).join("");
-    thead += "<th></th>";
-    let tbody = data.values.slice(0,100).map(row => {
-        let thumb = `<td><img loading="lazy" src="${thumbUrl}${ row.Id }/" /></td>`;
-        let tds = columnNames.map(col => `<td>${row[col] ? row[col] : ""}</td>`).join("");
-        let browse = `<td class="browse"><a target="_blank" title="Open this Image in another tab" href="${webindex}?show=image-${ row.Id }">Browse</a></td>`;
-        // let tds = row.key_values.map(kv => `<td>${kv.value}</td>`).join("");
-        return `<tr id="image-${ row.Id }">${thumb}${ tds }${browse}</tr>`;
-    }).join('\n');
+    let tbody = studyList
+      .map((row) => {
+        let studyName = row["Name (IDR number)"];
+        let tokens = studyName.split("-");
+        let studyId = tokens[0] + studyName.slice(studyName.length-1);
+        let tds = `<td>${studyId}</td><td>X</td><td>${studyName}</td>`;
+        return `<tr>${tds}</tr>`;
+      })
+      .join("\n");
 
     let table = `
         <thead>${thead}</thead>
         <tbody>${tbody}</tbody>
-    `
+    `;
     if (this.$table) {
       this.$table.html(table);
     }
@@ -443,36 +436,36 @@ class OmeroSearchForm {
 
   // Set-up event handlers on Buttons
   buttonHandlers() {
-    $("#addAND").on("click", event => {
+    $("#addAND").on("click", (event) => {
       event.preventDefault();
-      this.addAnd()
+      this.addAnd();
     });
 
-    this.$form.on("click", ".addOR", event => {
+    this.$form.on("click", ".addOR", (event) => {
       event.preventDefault();
       let $andClause = $(event.target).closest(".and_clause");
       this.addOr($andClause);
     });
 
-    this.$form.on("click", ".remove_row", event => {
+    this.$form.on("click", ".remove_row", (event) => {
       event.preventDefault();
       let $orClause = $(event.target).closest(".or_clause");
       this.removeOr($orClause);
     });
 
-    $("button[type='submit']", this.$form).on("click", event => {
+    $("button[type='submit']", this.$form).on("click", (event) => {
       event.preventDefault();
       this.submitSearch();
     });
 
     // table - filter button adds an AND filter
     if (this.$table) {
-      $(this.$table).on("click", ".filterColumn", event => {
+      $(this.$table).on("click", ".filterColumn", (event) => {
         event.preventDefault();
         // handle click in svg element within the button
         let $button = $(event.target).closest(".filterColumn");
         let colName = $button.data("colname");
-        this.addAnd({key: colName});
+        this.addAnd({ key: colName });
       });
     }
   }

--- a/idr_gallery/static/idr_gallery/omero_search_form.js
+++ b/idr_gallery/static/idr_gallery/omero_search_form.js
@@ -619,14 +619,9 @@ class OmeroSearchForm {
           alert(data["Error"]);
           return;
         }
-        if (
-          data?.results?.bookmark &&
-          data.results.page < data.results.total_pages
-        ) {
-          if (!$studyRow.data("bookmark")) {
-            // don't update if already exists
-            $studyRow.data("bookmark", data.results.bookmark);
-          }
+        let {page, total_pages, bookmark} = data.results;
+        if (bookmark && page < total_pages) {
+          $studyRow.data("bookmark", data.results.bookmark);
         } else {
           $studyRow.data("complete", true);
         }

--- a/idr_gallery/static/idr_gallery/omero_search_form.js
+++ b/idr_gallery/static/idr_gallery/omero_search_form.js
@@ -260,7 +260,6 @@ class OmeroSearchForm {
         source: function (request, response) {
           // Need to know what Attribute is of adjacent <select>
           key = $(".keyFields", $orClause).val();
-          console.log("key...", key);
           let url = `${SEARCH_ENGINE_URL}resources/image/searchvalues/?value=${encodeURI(
             request.term
           )}&resource=image`;
@@ -317,7 +316,6 @@ class OmeroSearchForm {
         },
         focus: function (event, ui) {},
         select: function (event, ui) {
-          console.log("select", ui.item, key == "Any");
           if (ui.item.value == -1) {
             // Ignore 'No results found'
             return false;
@@ -380,7 +378,6 @@ class OmeroSearchForm {
     $(".clauses", this.$form).empty();
 
     and_conditions.forEach((cond) => {
-      console.log("Adding AND", cond, this);
       this.addAnd(cond);
     });
 
@@ -401,7 +398,6 @@ class OmeroSearchForm {
     this.initAutoComplete($andClause);
     this.setKeyValues($andClause);
 
-    console.log("addAnd", query);
     if (query?.key) {
       // add <option> if not there
       this.setKeyField($andClause, query.key);
@@ -482,7 +478,6 @@ class OmeroSearchForm {
     let query = this.getCurrentQuery();
     query = this.modifyQueryCellTissue(query);
     let self = this;
-    console.log(query);
     this.$results.empty();
     this.showSpinner();
     $.ajax({
@@ -512,19 +507,7 @@ class OmeroSearchForm {
   }
 
   displayResults(data) {
-    console.log("displayResults", data);
-    // TODO: check how errors are handled
-    // if (data.Error && data.Error != "none") {
-    //     $("#dataTable").html(`<tr><td>${data.Error}</td></tr>`);
-    //     return;
-    // }
-
     let studyList = data.results.results;
-
-    if (studyList.length == 0) {
-      // TODO: improve display of message...
-      alert("No results");
-    }
 
     let thead = `<li class="studyRow resultsHeader">
       <div class="studyColumns">
@@ -569,7 +552,6 @@ class OmeroSearchForm {
 
   displayImages(data, $studyRow) {
     const imageList = data.results.results;
-    console.log("displayImages", imageList);
     let html = imageList
       .map((img) => {
         // Each humbnail links to image viewer. Hover menu links to viewer (eye) and webclient (i)
@@ -634,12 +616,10 @@ class OmeroSearchForm {
     // click on a Study to load child images...
     if (this.$results) {
       $(this.$results).on("click", ".studyColumns", (event) => {
-        console.log("studyRow click", event.target, event.target.nodeName);
         // ignore click on links...
         if (event.target.nodeName == "A") return;
         let $studyRow = $(event.target).parents(".studyRow");
         const studyName = $studyRow.data("name");
-        console.log($studyRow, studyName);
         if (!studyName) {
           return; // e.g. clicked on header
         }

--- a/idr_gallery/static/idr_gallery/omero_search_form.js
+++ b/idr_gallery/static/idr_gallery/omero_search_form.js
@@ -513,15 +513,18 @@ class OmeroSearchForm {
       .map((row) => {
         let studyName = row["Name (IDR number)"];
         let title = row["title"];
+        let objId = row["id"];
+        let objType = row["type"];
         let tokens = studyName.split("-");
         let studyId = tokens[0] + studyName.slice(studyName.length - 1);
         let count = row["image count"];
         return `<li class="studyRow" data-name="${studyName}">
             <div class="studyColumns">
                 <div class="caret"><i class="fa fa-caret-right"></i></div>
-                <div class="studyId">${studyId}</div>
+                <div class="studyId">
+                  <a href="${BASE_URL}webclient/?show=${objType}-${objId}" target="_blank">${studyId}</a></div>
                 <div class="count">${count}</div>
-                <div class="studyName">${title}</div>
+                <div class="studyName" title="${title}">${title}</div>
             </div>
             <div class="studyImages"><span class="loadingMsg">Loading images...</span></div>
         </li>`;

--- a/idr_gallery/static/idr_gallery/omero_search_form.js
+++ b/idr_gallery/static/idr_gallery/omero_search_form.js
@@ -182,14 +182,10 @@ class OmeroSearchForm {
     // Adds <option> to '.keyFields' for each item in pre-cached resources_data
     let $field = $(".keyFields", $orClause);
     let anyOption = `<option value="Any">Any</option>`;
-    let html = Object.entries(this.resources_data)
-      .map((keyValues) => {
-        keyValues[1].sort();
-        return keyValues[1]
-          .map((value) => `<option value="${value}">${value}</option>`)
-          .join("\n");
-      })
-      .join("\n");
+    // only show 'image' attributes
+    let imgKeys = this.resources_data.image;
+    imgKeys.sort();
+    let html = imgKeys.map((value) => `<option value="${value}">${value}</option>`).join("\n");
     $field.html(anyOption + html);
   }
 

--- a/idr_gallery/static/idr_gallery/omero_search_form.js
+++ b/idr_gallery/static/idr_gallery/omero_search_form.js
@@ -182,10 +182,16 @@ class OmeroSearchForm {
     // E.g. "Antibody equals seh1-fl antibody AND (Gene Symbol equals cdc42 OR Gene Symbol equals cdc25c)"
     let query = this.getCurrentQuery();
     // name, value, operator, resource
+    const maxLen = 50;
     let andQuery = query.query_details.and_filters
       .map(
+        // show tooltip and truncate if value is too long
         (q) =>
-          `<strong>${q.name}</strong> ${q.operator} <strong>${q.value}</strong>`
+          `<strong>${q.name}</strong>
+          ${q.operator}
+          <strong ${q.value.length > maxLen ? `title="${q.value}"` : ""}>
+            ${q.value.slice(0, maxLen)}${q.value.length > maxLen ? "..." : ""}
+          </strong>`
       )
       .join(" AND ");
     let orQueries = query.query_details.or_filters.map((ors) => {

--- a/idr_gallery/static/idr_gallery/omero_search_form.js
+++ b/idr_gallery/static/idr_gallery/omero_search_form.js
@@ -409,10 +409,11 @@ class OmeroSearchForm {
     let studyList = data.results.results;
 
     if (studyList.length == 0) {
+        // TODO: improve display of message...
         alert("No results");
     }
 
-    let thead = `<tr><th>${new Intl.NumberFormat().format(studyList.length)} Studies</th>`;
+    let thead = `<tr><th></th><th>Study ID</th>`;
     thead += `<th>Count</th><th>Title</th></tr>`;
 
     let tbody = studyList
@@ -420,8 +421,12 @@ class OmeroSearchForm {
         let studyName = row["Name (IDR number)"];
         let tokens = studyName.split("-");
         let studyId = tokens[0] + studyName.slice(studyName.length-1);
-        let tds = `<td>${studyId}</td><td>X</td><td>${studyName}</td>`;
-        return `<tr>${tds}</tr>`;
+        return `<tr class="studyRow" data-name="${studyName}">
+            <td><i class="fa fa-caret-right"></i></td>
+            <td>${studyId}</td>
+            <td>count?</td>
+            <td>${studyName}</td>
+        </tr>`;
       })
       .join("\n");
 
@@ -460,13 +465,22 @@ class OmeroSearchForm {
 
     // table - filter button adds an AND filter
     if (this.$table) {
-      $(this.$table).on("click", ".filterColumn", (event) => {
-        event.preventDefault();
-        // handle click in svg element within the button
-        let $button = $(event.target).closest(".filterColumn");
-        let colName = $button.data("colname");
-        this.addAnd({ key: colName });
-      });
+
+    //   $(this.$table).on("click", ".filterColumn", (event) => {
+    //     event.preventDefault();
+    //     // handle click in svg element within the button
+    //     let $button = $(event.target).closest(".filterColumn");
+    //     let colName = $button.data("colname");
+    //     this.addAnd({ key: colName });
+    //   });
+        $(this.$table).on("click", ".studyRow", (event) => {
+            console.log("studyRow click", event.target, event.target.nodeName);
+            // ignore click on links...
+            if (event.target.nodeName == 'A') return;
+            let $studyRow = $(event.target).parents(".studyRow");
+            console.log($studyRow, $studyRow.data("name"));
+            $studyRow.toggleClass("expanded");
+        });
     }
   }
 }

--- a/idr_gallery/static/idr_gallery/omero_search_form.js
+++ b/idr_gallery/static/idr_gallery/omero_search_form.js
@@ -505,6 +505,11 @@ class OmeroSearchForm {
       </div>
     </li>`;
 
+    // sort by image count
+    studyList.sort((a, b) => {
+      return a["image count"] > b["image count"] ? -1 : 1;
+    });
+
     let resultsList = studyList
       .map((row) => {
         let studyName = row["Name (IDR number)"];

--- a/idr_gallery/static/idr_gallery/omero_search_form.js
+++ b/idr_gallery/static/idr_gallery/omero_search_form.js
@@ -447,10 +447,20 @@ class OmeroSearchForm {
     console.log("displayImages", imageList);
     let html = imageList
       .map((img) => {
-        return `<img title="${img.name}" src="${BASE_URL}webclient/render_thumbnail/${img.id}/" />`;
+        return `<li class="studyThumb">
+          <img title="${img.name}" src="${BASE_URL}webclient/render_thumbnail/${img.id}/" />
+          <ul class="imgLinks">
+            <li title="Browse image metadata">
+              <a target="_blank" href="${BASE_URL}webclient/?show=image-${img.id}"><i class="fas fa-info"></i></a>
+            </li>
+            <li title="Open Image in Viewer">
+              <a target="_blank" href="${BASE_URL}webclient/img_detail/${img.id}"><i class="fas fa-eye"></i></a>
+            </li>
+          </ul>
+        </li>`;
       })
       .join("\n");
-    $(".studyImages", $studyRow).html(html);
+    $(".studyImages", $studyRow).html(`<ul>${html}</ul>`);
   }
 
   // Set-up event handlers on Buttons
@@ -477,9 +487,9 @@ class OmeroSearchForm {
       this.submitSearch();
     });
 
-    // table - filter button adds an AND filter
+    // click on a Study to load child images...
     if (this.$results) {
-      $(this.$results).on("click", ".studyRow", (event) => {
+      $(this.$results).on("click", ".studyColumns", (event) => {
         console.log("studyRow click", event.target, event.target.nodeName);
         // ignore click on links...
         if (event.target.nodeName == "A") return;

--- a/idr_gallery/static/idr_gallery/omero_search_form.js
+++ b/idr_gallery/static/idr_gallery/omero_search_form.js
@@ -466,8 +466,11 @@ class OmeroSearchForm {
     console.log("displayImages", imageList);
     let html = imageList
       .map((img) => {
+        // Each humbnail links to image viewer. Hover menu links to viewer (eye) and webclient (i)
         return `<li class="studyThumb">
-          <img title="${img.name}" src="${BASE_URL}webclient/render_thumbnail/${img.id}/" />
+          <a target="_blank" href="${BASE_URL}webclient/img_detail/${img.id}">
+            <img title="${img.name}" src="${BASE_URL}webclient/render_thumbnail/${img.id}/" />
+          </a>
           <ul class="imgLinks">
             <li title="Browse image metadata">
               <a target="_blank" href="${BASE_URL}webclient/?show=image-${img.id}"><i class="fas fa-info"></i></a>

--- a/idr_gallery/static/idr_gallery/omero_search_form.js
+++ b/idr_gallery/static/idr_gallery/omero_search_form.js
@@ -191,11 +191,12 @@ class OmeroSearchForm {
   autocompleteSort(queryVal) {
     // returns a sort function based on the current query Value
     // NB: same logic in autocompleteSort() function used on front page
+    queryVal = queryVal.toLowerCase();
     const KNOWN_KEYS = this.resources_data;
     return (a, b) => {
       // if exact match, show first
-      let aMatch = queryVal == a.Value;
-      let bMatch = queryVal == b.Value;
+      let aMatch = queryVal == a.Value.toLowerCase();
+      let bMatch = queryVal == b.Value.toLowerCase();
       if (aMatch != bMatch) {
         return aMatch ? -1 : 1;
       }

--- a/idr_gallery/static/idr_gallery/omero_search_form.js
+++ b/idr_gallery/static/idr_gallery/omero_search_form.js
@@ -469,7 +469,7 @@ class OmeroSearchForm {
         // Each humbnail links to image viewer. Hover menu links to viewer (eye) and webclient (i)
         return `<li class="studyThumb">
           <a target="_blank" href="${BASE_URL}webclient/img_detail/${img.id}">
-            <img title="${img.name}" src="${BASE_URL}webclient/render_thumbnail/${img.id}/" />
+            <img title="${img.name}" src="${BASE_URL}webclient/render_thumbnail/${img.id}/" loading="lazy" />
           </a>
           <ul class="imgLinks">
             <li title="Browse image metadata">

--- a/idr_gallery/static/idr_gallery/omero_search_form.js
+++ b/idr_gallery/static/idr_gallery/omero_search_form.js
@@ -448,8 +448,32 @@ class OmeroSearchForm {
     $("#filterSpinner").hide();
   }
 
+  modifyQueryCellTissue(query) {
+    // If /cell or /tissue, SUPER_CATEGORY.id
+    // NB: this uses global SUPER_CATEGORY variable
+    if (SUPER_CATEGORY?.id) {
+      let sampleType = SUPER_CATEGORY.id;
+      query.query_details["or_filters"].push([
+        {
+          name: "Sample Type",
+          value: sampleType,
+          resource: "screen",
+          operator: "equals",
+        },
+        {
+          name: "Sample Type",
+          value: sampleType,
+          resource: "project",
+          operator: "equals",
+        },
+      ]);
+    }
+    return query;
+  }
+
   submitSearch() {
     let query = this.getCurrentQuery();
+    query = this.modifyQueryCellTissue(query);
     let self = this;
     console.log(query);
     this.$results.empty();

--- a/idr_gallery/static/idr_gallery/omero_search_form.js
+++ b/idr_gallery/static/idr_gallery/omero_search_form.js
@@ -451,7 +451,7 @@ class OmeroSearchForm {
                 <div class="count">${count}</div>
                 <div class="studyName">${title}</div>
             </div>
-            <div class="studyImages">Loading images...</div>
+            <div class="studyImages"><span class="loadingMsg">Loading images...</span></div>
         </li>`;
       })
       .join("\n");

--- a/idr_gallery/static/idr_gallery/omero_search_form.js
+++ b/idr_gallery/static/idr_gallery/omero_search_form.js
@@ -270,15 +270,15 @@ class OmeroSearchForm {
         source: function (request, response) {
           // Need to know what Attribute is of adjacent <select>
           key = $(".keyFields", $orClause).val();
-          let url = `${SEARCH_ENGINE_URL}resources/image/searchvalues/?value=${encodeURI(
-            request.term
-          )}&resource=image`;
+          let data = { value: request.term };
+          let url = `${SEARCH_ENGINE_URL}resources/image/searchvalues/`;
           if (key != "Any") {
             url = url += `&key=${encodeURI(key)}`;
           }
           // showSpinner();
           $.ajax({
             dataType: "json",
+            data,
             type: "GET",
             url: url,
             success: function (data) {

--- a/idr_gallery/static/idr_gallery/omero_search_form.js
+++ b/idr_gallery/static/idr_gallery/omero_search_form.js
@@ -318,7 +318,7 @@ class OmeroSearchForm {
             },
           });
         },
-        minLength: 3,
+        minLength: 1,
         open: function () {},
         close: function () {
           // $(this).val('');

--- a/idr_gallery/static/idr_gallery/omero_search_form.js
+++ b/idr_gallery/static/idr_gallery/omero_search_form.js
@@ -181,9 +181,15 @@ class OmeroSearchForm {
     // E.g. "Antibody equals seh1-fl antibody AND (Gene Symbol equals cdc42 OR Gene Symbol equals cdc25c)"
     let query = this.getCurrentQuery();
     // name, value, operator, resource
-    let andQuery = query.query_details.and_filters.map(q => `${q.name} ${q.operator} ${q.value}`).join(" AND ");
-    let orQueries = query.query_details.or_filters.map(ors => {
-      return "(" + ors.map(q => `${q.name} ${q.operator} ${q.value}`).join(" OR ") + ")";
+    let andQuery = query.query_details.and_filters
+      .map((q) => `${q.name} ${q.operator} ${q.value}`)
+      .join(" AND ");
+    let orQueries = query.query_details.or_filters.map((ors) => {
+      return (
+        "(" +
+        ors.map((q) => `${q.name} ${q.operator} ${q.value}`).join(" OR ") +
+        ")"
+      );
     });
     let results = [];
     if (andQuery.length > 0) {
@@ -211,7 +217,9 @@ class OmeroSearchForm {
     // only show 'image' attributes
     let imgKeys = this.resources_data.image;
     imgKeys.sort();
-    let html = imgKeys.map((value) => `<option value="${value}">${value}</option>`).join("\n");
+    let html = imgKeys
+      .map((value) => `<option value="${value}">${value}</option>`)
+      .join("\n");
     $field.html(anyOption + html);
   }
 
@@ -361,25 +369,24 @@ class OmeroSearchForm {
 
   setQuery(jsonQuery) {
     // set complete state of form - opposite of getCurrentQuery()
-    
+
     const and_conditions = jsonQuery.query_details["and_filters"];
     const or_conditions = jsonQuery.query_details["or_filters"];
-    const case_sensitive = jsonQuery.query_details["case_sensitive"]
+    const case_sensitive = jsonQuery.query_details["case_sensitive"];
 
     document.getElementById("case_sensitive").checked = case_sensitive;
 
     // Clear form and create new...
     $(".clauses", this.$form).empty();
 
-    and_conditions.forEach(cond => {
+    and_conditions.forEach((cond) => {
       console.log("Adding AND", cond, this);
       this.addAnd(cond);
     });
 
-    or_conditions.forEach(or_clauses => {
-      
+    or_conditions.forEach((or_clauses) => {
       let $clause = this.addAnd(or_clauses[0]);
-      or_clauses.slice(1).forEach(or => {
+      or_clauses.slice(1).forEach((or) => {
         this.addOr($clause, or);
       });
     });

--- a/idr_gallery/templates/idr_gallery/background_carousel.html
+++ b/idr_gallery/templates/idr_gallery/background_carousel.html
@@ -26,8 +26,6 @@
         color: white;
         font-size: 200%;
         display: flex;
-        /* needs to be above main header content when narrow screen width */
-        z-index: 10;
     }
 
     .bg_controls div {

--- a/idr_gallery/templates/idr_gallery/index.html
+++ b/idr_gallery/templates/idr_gallery/index.html
@@ -314,23 +314,16 @@
     /* word-break: break-all; */
   }
   .searchScroll>div {
-    margin: 12px 0
+    padding: 5px 10px;
   }
 
   #hideSearchResults {
     border: none;
     background: none;
     position: absolute;
-    right: 25px;
+    right: 40px;
     top: 10px;
     z-index: 1;
-  }
-  /* overwrite foundation styles for table... */
-  #studySearchResults tbody {
-    border: none;
-  }
-  #studySearchResults tr {
-    background-color: transparent;
   }
 
   /* Always show scrollbars https://gist.github.com/IceCreamYou/cd517596e5847a88e2bb0a091da43fb4 */
@@ -446,10 +439,10 @@
 <div id="searchResultsContainer" class="row horizontal" style="display: none; position: relative; margin-top: -35px; margin-bottom: 15px">
   <div class="small-12 medium-12 large-12 columns">
     <button id="hideSearchResults" onclick="document.getElementById('searchResultsContainer').style.display = 'none'">X</button>
-    <div id="studySearchResults" class="panel" style="float: left; width: 100%; color: #333">
+    <div id="studySearchResults" class="panel" style="float: left; width: 100%; color: #333; padding: 0">
       Search results
     </div>
-    <div id="imageSearchResults" class="panel" style="float: left; width: 100%; color: #333">
+    <div id="imageSearchResults" class="panel" style="float: left; width: 100%; color: #333; padding: 0">
       <!-- spinner? -->
     </div>
   </div>

--- a/idr_gallery/templates/idr_gallery/index.html
+++ b/idr_gallery/templates/idr_gallery/index.html
@@ -376,6 +376,12 @@
   flex: 0;
   white-space: nowrap;
 }
+.imgCount, .matchingString, .black {
+  color: black;
+}
+.black {
+  font-weight: bold;
+}
 
 
 </style>

--- a/idr_gallery/templates/idr_gallery/index.html
+++ b/idr_gallery/templates/idr_gallery/index.html
@@ -364,6 +364,20 @@
     background-color: rgba(0, 0, 0, 0.5);
 }
 
+.matchingStudy {
+  display: flex;
+  flex-direction: row;
+  gap: 10px;
+}
+.matchingStudy div {
+  flex: 1
+}
+.matchingStudy div:first-child {
+  flex: 0;
+  white-space: nowrap;
+}
+
+
 </style>
 
 

--- a/idr_gallery/templates/idr_gallery/index.html
+++ b/idr_gallery/templates/idr_gallery/index.html
@@ -415,9 +415,9 @@
   <div id='search-form' class="row horizontal">
     <div class="small-12 medium-4 large-4 columns">
       <select id="maprConfig">
+        <option value="any">Choose search field (optional)</option>
         {% if filter_keys %}
         <optgroup id="studyKeys" label="Study Attributes">
-          <option value="any">Search by 'Any' key</option>
           {% for key in filter_keys %}
           <option value="{% if key.value %}{{ key.value }}{% else %}{{ key }}{% endif %}">
             {% if key.label %}{{ key.label }}{% else %}{{ key }}{% endif %}
@@ -431,7 +431,7 @@
       </select>
     </div>
     <div style="position: relative" class="small-12 medium-8 large-8 columns">
-      <input id="maprQuery" type="text" placeholder="Type to filter values...">
+      <input id="maprQuery" type="text" placeholder="Search for anything...">
       <svg id="spinner" aria-hidden="true" focusable="false" data-prefix="fas" data-icon="sync" role="img"
         xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" class="svg-inline--fa fa-sync fa-w-16 fa-spin fa-lg">
         <path fill="currentColor"

--- a/idr_gallery/templates/idr_gallery/index.html
+++ b/idr_gallery/templates/idr_gallery/index.html
@@ -16,6 +16,7 @@
   const IDR_STUDIES_URL = "{{ IDR_STUDIES_URL }}";
   const CATEGORY_QUERIES = {{ category_queries| safe }};
   var SUPER_CATEGORY {% if super_category %} = {{ super_category | safe }} {% endif %};
+  const SEARCH_ENGINE_URL = `${BASE_URL}searchengine/api/v1/`;
 </script>
 
 <script src="https://unpkg.com/@popperjs/core@2"></script>

--- a/idr_gallery/templates/idr_gallery/index.html
+++ b/idr_gallery/templates/idr_gallery/index.html
@@ -282,6 +282,9 @@
     background: yellow;
   }
 
+  #searchResultsContainer a {
+    font-weight: normal;
+  }
   #searchResults {
     position: relative;
   }

--- a/idr_gallery/templates/idr_gallery/index.html
+++ b/idr_gallery/templates/idr_gallery/index.html
@@ -313,6 +313,10 @@
     overflow-y: auto;
     /* word-break: break-all; */
   }
+  .searchScroll>div {
+    margin: 12px 0
+  }
+
   #hideSearchResults {
     border: none;
     background: none;

--- a/idr_gallery/templates/idr_gallery/mapr_search.html
+++ b/idr_gallery/templates/idr_gallery/mapr_search.html
@@ -1,0 +1,125 @@
+
+{% extends "idr_gallery/base.html" %}
+
+{% block content %}
+
+<style>
+  .study{
+    width: 247px;
+    height: 247px;
+  }
+  .study a:hover {
+    color: #1e94e6;
+  }
+  .maprViewerLink {
+    position: relative;
+  }
+  a.maprViewerLink div {
+    display: inline-block;
+    position:relative;
+  }
+  a.maprViewerLink i {
+    visibility: hidden;
+    color: white;
+    position: absolute;
+    top: 8px;
+    right: 8px;
+  }
+  a.maprViewerLink:hover i{
+    visibility: visible;
+  }
+  .exampleImages .thumbnail {
+    max-height: 45px;
+    max-width: 45px;
+  }
+  table td {
+    white-space: nowrap;
+  }
+  .filterMessage {
+    font-size: 120%;
+  }
+  .filterMessage strong {
+    color: #1976d2;
+  }
+</style>
+
+<hr class="whitespace" style="height: 0">
+
+<div class="row column text-center">
+
+<div class="small-12 small-centered medium-12 medium-centered columns">
+
+    <div id='search-form' class="row horizontal" style='display:none'>
+
+      <div class="small-12 medium-12 large-2 columns">
+        <h2 class="search-by">Search by:</h2>
+      </div>
+      <div style="padding:0" class="small-12 medium-4 large-3 columns">
+        <select id="maprConfig">
+          <optgroup id="studyKeys" style='display:none' label="Study Attributes">
+            {% if filter_keys %}
+            <optgroup id="studyKeys" label="Study Attributes">
+              {% for key in filter_keys %}
+              <option value="{% if key.value %}{{ key.value }}{% else %}{{ key }}{% endif %}">
+                {% if key.label %}{{ key.label }}{% else %}{{ key }}{% endif %}
+              </option>`
+              {% endfor %}
+            </optgroup>
+            {% endif %}
+          <optgroup id="maprKeys" style='display:none' label="Image Attributes">
+          </optgroup>
+        </select>
+      </div>
+      <div style="position: relative" class="small-12 medium-8 large-7 columns">
+        <input id="maprQuery" type="text" placeholder="Type to filter values..." style="width: calc(100% - 40px)">
+        <svg id="spinner" aria-hidden="true" focusable="false" data-prefix="fas" data-icon="sync" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" class="svg-inline--fa fa-sync fa-w-16 fa-spin fa-lg"><path fill="currentColor" d="M440.65 12.57l4 82.77A247.16 247.16 0 0 0 255.83 8C134.73 8 33.91 94.92 12.29 209.82A12 12 0 0 0 24.09 224h49.05a12 12 0 0 0 11.67-9.26 175.91 175.91 0 0 1 317-56.94l-101.46-4.86a12 12 0 0 0-12.57 12v47.41a12 12 0 0 0 12 12H500a12 12 0 0 0 12-12V12a12 12 0 0 0-12-12h-47.37a12 12 0 0 0-11.98 12.57zM255.83 432a175.61 175.61 0 0 1-146-77.8l101.8 4.87a12 12 0 0 0 12.57-12v-47.4a12 12 0 0 0-12-12H12a12 12 0 0 0-12 12V500a12 12 0 0 0 12 12h47.35a12 12 0 0 0 12-12.6l-4.15-82.57A247.17 247.17 0 0 0 255.83 504c121.11 0 221.93-86.92 243.55-201.82a12 12 0 0 0-11.8-14.18h-49.05a12 12 0 0 0-11.67 9.26A175.86 175.86 0 0 1 255.83 432z" class=""></path></svg>
+        <a class="button"
+          title="Clear filter"
+          style="position: absolute; top: 0; right: 0; color: #bbb; border-radius: 15px; background: white; border: solid #bbb 1px;"
+          {% if category %}
+            href="{% url 'gallery_super_category' super_category=category %}"
+          {% else %}
+            href="{% url 'idr_gallery_index' %}"
+          {% endif %}
+          >X</a>
+      </div>
+
+      <div id="filterCount" class="row horizontal">
+      </div>
+    </div>
+
+    <div id="filterSpinner" class="row horizontal">
+      <div id="filterSpinnerMessage">
+        <!-- Show a waiting... message here -->
+      </div>
+      <svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="sync" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" class="svg-inline--fa fa-sync fa-w-16 fa-spin fa-lg"><path fill="currentColor" d="M440.65 12.57l4 82.77A247.16 247.16 0 0 0 255.83 8C134.73 8 33.91 94.92 12.29 209.82A12 12 0 0 0 24.09 224h49.05a12 12 0 0 0 11.67-9.26 175.91 175.91 0 0 1 317-56.94l-101.46-4.86a12 12 0 0 0-12.57 12v47.41a12 12 0 0 0 12 12H500a12 12 0 0 0 12-12V12a12 12 0 0 0-12-12h-47.37a12 12 0 0 0-11.98 12.57zM255.83 432a175.61 175.61 0 0 1-146-77.8l101.8 4.87a12 12 0 0 0 12.57-12v-47.4a12 12 0 0 0-12-12H12a12 12 0 0 0-12 12V500a12 12 0 0 0 12 12h47.35a12 12 0 0 0 12-12.6l-4.15-82.57A247.17 247.17 0 0 0 255.83 504c121.11 0 221.93-86.92 243.55-201.82a12 12 0 0 0-11.8-14.18h-49.05a12 12 0 0 0-11.67 9.26A175.86 175.86 0 0 1 255.83 432z" class=""></path></svg>
+    </div>
+
+    <div id="studies" class="row horizontal">
+      Loading Studies...
+    </div>
+</div>
+
+</div>
+
+<script>
+  // Various global constants from omero config set...
+  var FILTER_KEYS = {{ filter_keys|safe }};
+  var FILTER_MAPR_KEYS = {{ filter_mapr_keys|safe }};
+  // e.g. GALLEY_INDEX/api-gallery/thumbnails for loading from IDR
+  const GALLERY_INDEX = "{{ gallery_index }}";
+  // this is the home of this app, e.g. for GALLERY_HOME/search/
+  const GALLERY_HOME = "{% url 'idr_gallery_index' %}";
+  const BASE_URL = "{{ base_url }}";
+  const CATEGORY_QUERIES = {{ category_queries|safe }};
+  var TITLE_KEYS = {{ TITLE_KEYS|safe }};
+  var STUDY_SHORT_NAME = {{ STUDY_SHORT_NAME|safe }};
+  var SUPER_CATEGORIES = {{ SUPER_CATEGORIES|safe }};
+  var SUPER_CATEGORY {% if super_category %} = {{ super_category|safe }} {% endif %};
+  var STATIC_DIR = "{% static 'gallery/' %}";
+</script>
+
+<script src="{% static 'idr_gallery/search.js' %}?_={{VERSION}}"></script>
+<script src="{% static 'idr_gallery/autocomplete.js' %}?_={{VERSION}}"></script>
+
+{% endblock %}

--- a/idr_gallery/templates/idr_gallery/search.html
+++ b/idr_gallery/templates/idr_gallery/search.html
@@ -44,13 +44,29 @@
   #results td, #results th {
     text-align: center;
   }
+  #filterCount {
+    clear: right;
+  }
+
+  /* Hide form elements to simplify */
+  #addAND, .addOR, .form-check-label {
+    display: none;
+  }
+  button[type='submit'] {
+    background: #1976d2;
+    float: right;
+    color: white;
+    padding: 10px;
+    border-radius: 10px;
+    margin: 5px;
+  }
 </style>
 
 <link rel="stylesheet" href="{% static 'idr_gallery/css/search_form_styles.css' %}?_={{VERSION}}" />
 
 <hr class="whitespace" style="height: 0">
 
-<div class="row column text-center">
+<div class="row column">
 
 <div class="small-12 small-centered medium-12 medium-centered columns">
 
@@ -59,7 +75,7 @@
       <form id="search_form">
       </form>
 
-      <div id="filterCount" class="row horizontal">
+      <div id="filterCount" class="row horizontal text-center">
         <!-- results message here -->
       </div>
     </div>

--- a/idr_gallery/templates/idr_gallery/search.html
+++ b/idr_gallery/templates/idr_gallery/search.html
@@ -52,7 +52,9 @@
   #addAND, .addOR, .form-check-label {
     display: none;
   }
+  /* hidden for now */
   button[type='submit'] {
+    display: none;
     background: #1976d2;
     float: right;
     color: white;
@@ -92,7 +94,7 @@
       </div>
     </div>
 
-    <div id="filterSpinner" class="row horizontal">
+    <div id="filterSpinner" class="row horizontal text-center">
       <div id="filterSpinnerMessage">
         <!-- Show a waiting... message here -->
       </div>

--- a/idr_gallery/templates/idr_gallery/search.html
+++ b/idr_gallery/templates/idr_gallery/search.html
@@ -144,30 +144,26 @@
   searchForm.on("form_updated", function(event, data) {
     // Update URL, adding to browser's history
     let search_query = searchForm.getCurrentQuery();
+    // for now, we only support the first AND clause...
+    console.log(search_query.query_details.and_filters);
+    const clause = search_query.query_details.and_filters[0];
     let params = new URLSearchParams();
-    params.append("search_query", JSON.stringify(search_query));
-    console.log("params", params.toString().length);
+    params.append("key", clause.name);
+    params.append("value", clause.value);
+    params.append("operator", clause.operator);
     history.pushState(null, "", "?" + params.toString());
   });
 
 
   function searchFromUrl() {
     const searchParams = new URLSearchParams(window.location.search);
-    let query = searchParams.get("search_query");
-    console.log("searchFromUrl", query);
-    try {
-      const queryJson = JSON.parse(query);
-      searchForm.setQuery(queryJson);
+    let key = searchParams.get("key");
+    let value = searchParams.get("value");
+    console.log("searchFromUrl", key, value);
+    if (key && value) {
+      let operator = searchParams.get("operator", "equals");
+      searchForm.setKeyValueQuery({key, value, operator});
       searchForm.submitSearch();
-    } catch (error) {
-      if (query.includes(":")) {
-        let colonIndex = query.indexOf(":");
-        let name = query.substring(0, colonIndex);
-        let value = query.substring(colonIndex + 1);
-        console.log("Name", name, "Value", value);
-        searchForm.setKeyValueQuery({name, value});
-        searchForm.submitSearch();
-      }
     }
     // 'hidden' support for ?advanced=true to show AND/OR buttons
     let advanced = searchParams.get("advanced");

--- a/idr_gallery/templates/idr_gallery/search.html
+++ b/idr_gallery/templates/idr_gallery/search.html
@@ -90,7 +90,7 @@
     <div id="studies" class="row horizontal">
     </div>
 
-    <table id="results"></table>
+    <ul id="results" class="resultsList"></ul>
 </div>
 
 </div>

--- a/idr_gallery/templates/idr_gallery/search.html
+++ b/idr_gallery/templates/idr_gallery/search.html
@@ -137,8 +137,9 @@
     let studiesList = data.results.results;
     let imgCount = studiesList.reduce((prev, study) => prev += study["image count"], 0);
     let studies = studiesList.length === 1 ? 'study' : 'studies';
+    let searchQuery = searchForm.getHumanReadableQuery();
     let msg = `<p class="filterMessage">
-      Found <strong>${imgCount}</strong> images in <strong>${studiesList.length}</strong> ${studies}
+      Search <strong>${searchQuery}</strong> found <strong>${imgCount}</strong> images in <strong>${studiesList.length}</strong> ${studies}
     </p>`;
     document.getElementById("filterCount").innerHTML = msg;
   });

--- a/idr_gallery/templates/idr_gallery/search.html
+++ b/idr_gallery/templates/idr_gallery/search.html
@@ -43,46 +43,18 @@
   }
 </style>
 
+<link rel="stylesheet" href="{% static 'idr_gallery/css/search_form_styles.css' %}?_={{VERSION}}" />
+
 <hr class="whitespace" style="height: 0">
 
 <div class="row column text-center">
 
 <div class="small-12 small-centered medium-12 medium-centered columns">
 
-    <div id='search-form' class="row horizontal" style='display:none'>
+    <div class="row horizontal">
 
-      <div class="small-12 medium-12 large-2 columns">
-        <h2 class="search-by">Search by:</h2>
-      </div>
-      <div style="padding:0" class="small-12 medium-4 large-3 columns">
-        <select id="maprConfig">
-          <optgroup id="studyKeys" style='display:none' label="Study Attributes">
-            {% if filter_keys %}
-            <optgroup id="studyKeys" label="Study Attributes">
-              {% for key in filter_keys %}
-              <option value="{% if key.value %}{{ key.value }}{% else %}{{ key }}{% endif %}">
-                {% if key.label %}{{ key.label }}{% else %}{{ key }}{% endif %}
-              </option>`
-              {% endfor %}
-            </optgroup>
-            {% endif %}
-          <optgroup id="maprKeys" style='display:none' label="Image Attributes">
-          </optgroup>
-        </select>
-      </div>
-      <div style="position: relative" class="small-12 medium-8 large-7 columns">
-        <input id="maprQuery" type="text" placeholder="Type to filter values..." style="width: calc(100% - 40px)">
-        <svg id="spinner" aria-hidden="true" focusable="false" data-prefix="fas" data-icon="sync" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" class="svg-inline--fa fa-sync fa-w-16 fa-spin fa-lg"><path fill="currentColor" d="M440.65 12.57l4 82.77A247.16 247.16 0 0 0 255.83 8C134.73 8 33.91 94.92 12.29 209.82A12 12 0 0 0 24.09 224h49.05a12 12 0 0 0 11.67-9.26 175.91 175.91 0 0 1 317-56.94l-101.46-4.86a12 12 0 0 0-12.57 12v47.41a12 12 0 0 0 12 12H500a12 12 0 0 0 12-12V12a12 12 0 0 0-12-12h-47.37a12 12 0 0 0-11.98 12.57zM255.83 432a175.61 175.61 0 0 1-146-77.8l101.8 4.87a12 12 0 0 0 12.57-12v-47.4a12 12 0 0 0-12-12H12a12 12 0 0 0-12 12V500a12 12 0 0 0 12 12h47.35a12 12 0 0 0 12-12.6l-4.15-82.57A247.17 247.17 0 0 0 255.83 504c121.11 0 221.93-86.92 243.55-201.82a12 12 0 0 0-11.8-14.18h-49.05a12 12 0 0 0-11.67 9.26A175.86 175.86 0 0 1 255.83 432z" class=""></path></svg>
-        <a class="button"
-          title="Clear filter"
-          style="position: absolute; top: 0; right: 0; color: #bbb; border-radius: 15px; background: white; border: solid #bbb 1px;"
-          {% if category %}
-            href="{% url 'gallery_super_category' super_category=category %}"
-          {% else %}
-            href="{% url 'idr_gallery_index' %}"
-          {% endif %}
-          >X</a>
-      </div>
+      <form id="search_form">
+      </form>
 
       <div id="filterCount" class="row horizontal">
       </div>
@@ -96,8 +68,9 @@
     </div>
 
     <div id="studies" class="row horizontal">
-      Loading Studies...
     </div>
+
+    <table id="results"></table>
 </div>
 
 </div>
@@ -117,9 +90,28 @@
   var SUPER_CATEGORIES = {{ SUPER_CATEGORIES|safe }};
   var SUPER_CATEGORY {% if super_category %} = {{ super_category|safe }} {% endif %};
   var STATIC_DIR = "{% static 'gallery/' %}";
+  var SEARCH_ENGINE_URL = `${BASE_URL}searchengine/api/v1/`;
 </script>
 
-<script src="{% static 'idr_gallery/search.js' %}?_={{VERSION}}"></script>
-<script src="{% static 'idr_gallery/autocomplete.js' %}?_={{VERSION}}"></script>
+<script src="{% static 'idr_gallery/omero_search_form.js' %}?_={{VERSION}}"></script>
+
+<script>
+  const searchForm = new OmeroSearchForm("search_form", SEARCH_ENGINE_URL, "results");
+
+  const searchParams = new URLSearchParams(window.location.search);
+  let query = searchParams.get("search_query");
+  console.log("query", query);
+  if (query && query.includes(":")) {
+      // Use first ":" to split Key:Value...
+      let colonIndex = query.indexOf(":");
+      let key = query.substring(0, colonIndex);
+      let value = query.substring(colonIndex + 1);
+      console.log("Key", key, "Value", value);
+      searchForm.on("ready", function(){
+          searchForm.setQuery({key, value});
+          searchForm.submitSearch();
+      });
+  }
+</script>
 
 {% endblock %}

--- a/idr_gallery/templates/idr_gallery/search.html
+++ b/idr_gallery/templates/idr_gallery/search.html
@@ -139,7 +139,7 @@
   searchForm.on("results", function(event, data) {
     console.log("on.results", event, data);
     let studiesList = data.results.results;
-    let imgCount = 0;
+    let imgCount = studiesList.reduce((prev, study) => prev += study["image count"], 0);
     let studies = studiesList.length === 1 ? 'study' : 'studies';
     let msg = `<p class="filterMessage">
       Found <strong>${imgCount}</strong> images in <strong>${studiesList.length}</strong> ${studies}

--- a/idr_gallery/templates/idr_gallery/search.html
+++ b/idr_gallery/templates/idr_gallery/search.html
@@ -145,7 +145,6 @@
     // Update URL, adding to browser's history
     let search_query = searchForm.getCurrentQuery();
     // for now, we only support the first AND clause...
-    console.log(search_query.query_details.and_filters);
     const clause = search_query.query_details.and_filters[0];
     let params = new URLSearchParams();
     params.append("key", clause.name);
@@ -159,7 +158,6 @@
     const searchParams = new URLSearchParams(window.location.search);
     let key = searchParams.get("key");
     let value = searchParams.get("value");
-    console.log("searchFromUrl", key, value);
     if (key && value) {
       let operator = searchParams.get("operator", "equals");
       searchForm.setKeyValueQuery({key, value, operator});

--- a/idr_gallery/templates/idr_gallery/search.html
+++ b/idr_gallery/templates/idr_gallery/search.html
@@ -128,9 +128,6 @@
 <script>
   const searchForm = new OmeroSearchForm("search_form", SEARCH_ENGINE_URL, "results");
 
-  const searchParams = new URLSearchParams(window.location.search);
-  let query = searchParams.get("search_query");
-
   // custom handling of search results, not handled by OmeroSearchForm
   searchForm.on("results", function(event, data) {
     console.log("on.results", event, data);
@@ -144,26 +141,54 @@
     document.getElementById("filterCount").innerHTML = msg;
   });
 
-  console.log("query", query);
-  if (query && query.includes(":")) {
-      // Use first ":" to split Key:Value...
-      let colonIndex = query.indexOf(":");
-      let key = query.substring(0, colonIndex);
-      let value = query.substring(colonIndex + 1);
-      console.log("Key", key, "Value", value);
-      searchForm.on("ready", function(){
-          searchForm.setQuery({key, value});
-          searchForm.submitSearch();
-      });
+  searchForm.on("form_updated", function(event, data) {
+    // Update URL, adding to browser's history
+    let search_query = searchForm.getCurrentQuery();
+    let params = new URLSearchParams();
+    params.append("search_query", JSON.stringify(search_query));
+    console.log("params", params.toString().length);
+    history.pushState(null, "", "?" + params.toString());
+  });
+
+
+  function searchFromUrl() {
+    const searchParams = new URLSearchParams(window.location.search);
+    let query = searchParams.get("search_query");
+    console.log("searchFromUrl", query);
+    try {
+      const queryJson = JSON.parse(query);
+      searchForm.setQuery(queryJson);
+      searchForm.submitSearch();
+    } catch (error) {
+      if (query.includes(":")) {
+        let colonIndex = query.indexOf(":");
+        let name = query.substring(0, colonIndex);
+        let value = query.substring(colonIndex + 1);
+        console.log("Name", name, "Value", value);
+        searchForm.setKeyValueQuery({name, value});
+        searchForm.submitSearch();
+      }
+    }
+    // 'hidden' support for ?advanced=true to show AND/OR buttons
+    let advanced = searchParams.get("advanced");
+    if (advanced) {
+      searchForm.setAdvanced(true);
+    } else {
+      searchForm.setAdvanced(false);
+    }
   }
 
-  // 'hidden' support for ?advanced=true to show AND/OR buttons
-  let advanced = searchParams.get("advanced");
-  if (advanced) {
-    searchForm.setAdvanced(true);
-  } else {
-    searchForm.setAdvanced(false);
+
+  searchForm.on("ready", function(){
+    searchFromUrl();
+  });
+
+
+  window.onpopstate = (event) => {
+    console.log(`onpopstate location: ${document.location}, state: ${JSON.stringify(event.state)}`)
+    searchFromUrl();
   }
+
 </script>
 
 {% endblock %}

--- a/idr_gallery/templates/idr_gallery/search.html
+++ b/idr_gallery/templates/idr_gallery/search.html
@@ -41,6 +41,9 @@
   .filterMessage strong {
     color: #1976d2;
   }
+  #results td, #results th {
+    text-align: center;
+  }
 </style>
 
 <link rel="stylesheet" href="{% static 'idr_gallery/css/search_form_styles.css' %}?_={{VERSION}}" />
@@ -57,6 +60,7 @@
       </form>
 
       <div id="filterCount" class="row horizontal">
+        <!-- results message here -->
       </div>
     </div>
 
@@ -100,6 +104,19 @@
 
   const searchParams = new URLSearchParams(window.location.search);
   let query = searchParams.get("search_query");
+
+  // custom handling of search results, not handled by OmeroSearchForm
+  searchForm.on("results", function(event, data) {
+    console.log("on.results", event, data);
+    let studiesList = data.results.results;
+    let imgCount = 0;
+    let studies = studiesList.length === 1 ? 'study' : 'studies';
+    let msg = `<p class="filterMessage">
+      Found <strong>${imgCount}</strong> images in <strong>${studiesList.length}</strong> ${studies}
+    </p>`;
+    document.getElementById("filterCount").innerHTML = msg;
+  });
+
   console.log("query", query);
   if (query && query.includes(":")) {
       // Use first ":" to split Key:Value...

--- a/idr_gallery/templates/idr_gallery/search.html
+++ b/idr_gallery/templates/idr_gallery/search.html
@@ -64,7 +64,19 @@
 
 <link rel="stylesheet" href="{% static 'idr_gallery/css/search_form_styles.css' %}?_={{VERSION}}" />
 
-<hr class="whitespace" style="height: 0">
+<div class="row column">
+  <!-- Home button - bit painful to handle /cell/search etc -->
+  <a  {% if super_category %}
+        {% for c, data in super_categories.items %}
+          {% if c == category %} href="{% url 'gallery_super_category' super_category=c %}" {% endif %}
+        {% endfor %}
+      {% else %}
+        href="{% url 'idr_gallery_index' %}"
+      {% endif %}
+        style="background: #263238; border-radius: 10px; color: #eceff1; padding: 10px; margin:10px 5px 5px; display: inline-block; font-weight: normal;">
+    <i class="fa fa-caret-left"></i> Home
+  </a>
+</div>
 
 <div class="row column">
 

--- a/idr_gallery/templates/idr_gallery/search.html
+++ b/idr_gallery/templates/idr_gallery/search.html
@@ -136,7 +136,7 @@
     let studies = studiesList.length === 1 ? 'study' : 'studies';
     let searchQuery = searchForm.getHumanReadableQuery();
     let msg = `<p class="filterMessage">
-      Search <strong>${searchQuery}</strong> found <strong>${imgCount}</strong> images in <strong>${studiesList.length}</strong> ${studies}
+      Search ${searchQuery} found <strong>${imgCount}</strong> images in <strong>${studiesList.length}</strong> ${studies}
     </p>`;
     document.getElementById("filterCount").innerHTML = msg;
   });

--- a/idr_gallery/templates/idr_gallery/search.html
+++ b/idr_gallery/templates/idr_gallery/search.html
@@ -48,11 +48,7 @@
     clear: right;
   }
 
-  /* Hide form elements to simplify */
-  #addAND, .addOR, .form-check-label {
-    display: none;
-  }
-  /* hidden for now */
+  /* 'Search' button hidden for now */
   button[type='submit'] {
     display: none;
     background: #1976d2;
@@ -158,6 +154,14 @@
           searchForm.setQuery({key, value});
           searchForm.submitSearch();
       });
+  }
+
+  // 'hidden' support for ?advanced=true to show AND/OR buttons
+  let advanced = searchParams.get("advanced");
+  if (advanced) {
+    searchForm.setAdvanced(true);
+  } else {
+    searchForm.setAdvanced(false);
   }
 </script>
 

--- a/idr_gallery/urls.py
+++ b/idr_gallery/urls.py
@@ -11,8 +11,7 @@ urlpatterns = [
     url(r'^gallery_settings/$', views.gallery_settings),
 
     # Search page shows Projects / Screens filtered by Map Annotation
-    url(r'^search/$', views.index, {
-        'super_category': None, 'template': 'idr_gallery/search.html'}),
+    url(r'^search/$', views.index, {'super_category': None}),
 
     # Supports e.g. ?project=1&project=2&screen=3
     url(r'^gallery-api/thumbnails/$', views.api_thumbnails,
@@ -23,5 +22,4 @@ for c in SUPER_CATEGORIES:
     urlpatterns.append(url(r'^%s/$' % c, views.index, {'super_category': c},
                            name="gallery_super_category"))
     urlpatterns.append(url(r'^%s/search/$' % c, views.index,
-                           {'super_category': c,
-                            'template': 'idr_gallery/search.html'}))
+                           {'super_category': c}))

--- a/idr_gallery/views.py
+++ b/idr_gallery/views.py
@@ -32,7 +32,15 @@ def index(request, super_category=None, conn=None, **kwargs):
     """
 
     # template is different for '/search' page
-    context = {'template': kwargs.get('template', "idr_gallery/index.html")}
+    template = "idr_gallery/index.html"
+    if "search" in request.path:
+        query = request.GET.get("query")
+        # TEMP: support deprecated ?query=K:V
+        if query:
+            template = "idr_gallery/mapr_search.html"
+        else:
+            template = "idr_gallery/search.html"
+    context = {'template': template}
     context["idr_images"] = IDR_IMAGES
     if super_category == "cell":
         context["idr_images"] = CELL_IMAGES


### PR DESCRIPTION
This work is an exploration of ideas for accessing new elastic-search functionality from the IDR front page.

This uses a URL endpoint that allows for searching for values from "Any" key-value pair to provide auto-complete response for all Images in IDR.

This is combined with filtering of the key-value pairs and Descriptions for all Studies that are already loaded into the front page. The resulting auto-complete gives results for Images and Studies in a single list:

EDIT: see comments below for more up-to-date screenshots...

<img width="1247" alt="Screenshot 2022-04-11 at 11 44 44" src="https://user-images.githubusercontent.com/900055/162728528-c419a089-5b3f-4600-b6f6-fe7f35690fb1.png">

The filtering of Studies is based on the experimental filtering (now hidden on the idr front page) which can be enabled by typing this into the browser console: `$("#filterText").parent().show()`;
That code provided a nicer experience of filtering studies, since the result showed a list of studies (see below), whereas the auto-complete shows a list of *values*.

<img width="799" alt="Screenshot 2022-04-11 at 12 19 41" src="https://user-images.githubusercontent.com/900055/162729367-d357ac42-ddbf-4325-9b3c-29a61a4d0bdc.png">

Or filtering for "Zebrafish" studies:
<img width="786" alt="Screenshot 2022-04-11 at 13 27 57" src="https://user-images.githubusercontent.com/900055/162739852-83bf4028-8671-4cd9-9c95-44227116a8ef.png">

Compare to searching for "Zebra..." in this auto-complete PR. It shows the Values that contain "Zebra" but it's hard to identify the study from those:

<img width="1249" alt="Screenshot 2022-04-11 at 13 34 39" src="https://user-images.githubusercontent.com/900055/162740637-b8b257f4-801f-4337-b471-fc330b119869.png">


