### PR TITLE
scroll auto-complete if longer than 450 pixels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+3.6.1 (August 2022)
+-------------------
+
+- Fix scrolling on auto-complete results [#10](https://github.com/IDR/idr-gallery/pull/10)
+
 3.6.0 (March 2022)
 ------------------
 

--- a/idr_gallery/static/idr_gallery/studies.css
+++ b/idr_gallery/static/idr_gallery/studies.css
@@ -126,6 +126,9 @@ maprText {
 .ui-autocomplete {
   padding-left: 20px;
   text-indent: -10px;
+  /* scroll if longer than... */
+  max-height: 450px;
+  overflow: auto
 }
 
 #studies.studiesLayout {


### PR DESCRIPTION
As discussed at meeting this morning, some auto-complete lists are quite long and require scrolling. This PR restricts the length of the drop-down list (with it's own scrollbar) so that you don't have to scroll the whole page:

![Screenshot 2022-08-15 at 12 20 03](https://user-images.githubusercontent.com/900055/184626658-ba45d6c5-abd7-44bc-81ad-aae155cfae18.png)

