### PR TITLE
Redirect mapr search URLs to searchengine page

### DIFF
--- a/idr_gallery/urls.py
+++ b/idr_gallery/urls.py
@@ -11,7 +11,8 @@ urlpatterns = [
     url(r'^gallery_settings/$', views.gallery_settings),
 
     # Search page shows Projects / Screens filtered by Map Annotation
-    url(r'^search/$', views.index, {'super_category': None}),
+    url(r'^search/$', views.index, {'super_category': None},
+        name="idr_gallery_search"),
 
     # Supports e.g. ?project=1&project=2&screen=3
     url(r'^gallery-api/thumbnails/$', views.api_thumbnails,


### PR DESCRIPTION
This redirects mapr search pages to search engine page.
E.g. https://idr.openmicroscopy.org/search/?query=mapr_gene:PAX6 will redirect to /search/?key=Gene+Symbol&value=pax6&operator=equals

To test, use mapr search on existing idr server, then use that same URL on the testing server.
OR, use testing server and search by mapr "Image Attributes" from the home page.. This will generate the same mapr URL as before, which will then get redirected to search engine.

NB: For URLs like https://idr.openmicroscopy.org/search/?query=mapr_gene:ENSG00000132341 that is actually the `Gene Identifier`
For keys like 'gene' that mapr uses to cover 2 keys (`Gene Symbol` and `Gene Identifier`) we now use the search_engine to find which key matches the given value.

The other examples are "Phenotype" & "Phenotype Term Accession" and "siRNA Identifier" & "siRNA Pool Identifier"
