### PR TITLE
Fix image loading pagination to use new pagination info

### DIFF
--- a/idr_gallery/static/idr_gallery/omero_search_form.js
+++ b/idr_gallery/static/idr_gallery/omero_search_form.js
@@ -597,7 +597,6 @@ class OmeroSearchForm {
 
   loadStudyImages($studyRow) {
     const studyName = $studyRow.data("name");
-    const bookmark = $studyRow.data("bookmark");
     if ($studyRow.hasClass("loading") || $studyRow.data("complete")) {
       return;
     }
@@ -612,9 +611,10 @@ class OmeroSearchForm {
       operator: "equals",
       resource: "project", // NB: this works for screens too!
     });
-    // if bookmark exists, we are loading next pages...
-    if (bookmark) {
-      query.bookmark = bookmark;
+    // if pagination data object exists, we are loading next pages...
+    const pagination = $studyRow.data("pagination");
+    if (pagination) {
+      query.pagination = pagination;
     }
     $studyRow.addClass("loading", true); // shows spinner
     $.ajax({
@@ -628,9 +628,10 @@ class OmeroSearchForm {
           alert(data["Error"]);
           return;
         }
-        let { page, total_pages, bookmark } = data.results;
-        if (bookmark && page < total_pages) {
-          $studyRow.data("bookmark", data.results.bookmark);
+        let { total_pages, pagination } = data.results;
+        let page = data.results.pagination.current_page;
+        if (pagination && page < total_pages) {
+          $studyRow.data("pagination", pagination);
         } else {
           $studyRow.data("complete", true);
         }


### PR DESCRIPTION
Fix pagination.. - This commit was originally pushed and tested at https://github.com/IDR/idr-gallery/pull/15

For results where there are more than 1000 images in a Study, the images are loaded in pages of 1000 images at a time when user scrolls to the bottom of the panel (spinner shows while loading).
After the last page loads, there should be no spinner showing, no console errors etc.
Test on a result with more than 2000 images in a Study (since 2 pages happened to work OK before).
Requires https://github.com/ome/omero_search_engine/pull/56