### PR TITLE
Remove not_equals and not_contains options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+3.7.0 (September 2022)
+----------------------
+
+- Support searching with `omero_search_engine` backend [#8](https://github.com/IDR/idr-gallery/pull/8), with updates in [#16](https://github.com/IDR/idr-gallery/pull/16) and [#18](https://github.com/IDR/idr-gallery/pull/18)
+
 3.6.2 (August 2022)
 -------------------
 

--- a/idr_gallery/static/idr_gallery/omero_search_form.js
+++ b/idr_gallery/static/idr_gallery/omero_search_form.js
@@ -11,9 +11,7 @@ const AND_CLAUSE_HTML = `
         <label for="condition">Operator</label>
         <select id="condition" class="form-control condition">
           <option value="equals">equals</option>
-          <option value="not_equals">not equals</option>
           <option value="contains">contains</option>
-          <option value="not_contains">not contains</option>
         </select>
     </div>
     <div class="search_value" style="position: relative">


### PR DESCRIPTION
As discussed this morning, the `not_equals` and `not_contains` options can lead to confusion with auto-complete, and aren't really needed given the current UI which only allows a single query.

Also add changelog entry for `3.7.0`