### PR TITLE
Fix handling of no studies.tsv containers for studyId

### DIFF
--- a/idr_gallery/static/idr_gallery/categories.js
+++ b/idr_gallery/static/idr_gallery/categories.js
@@ -216,10 +216,10 @@ function imageCount(idrId, container) {
   if (!model.studyStats) return "";
 
   let containers = model.studyStats[idrId];
+  if (!containers) return "";
   if (container) {
     containers.filter((c) => c.Container == container);
   }
-  if (!containers) return "";
 
   let imgCount = containers
     .map((row) => row["5D Images"])


### PR DESCRIPTION
Fixes a bug seen on idr-next when the studies.tsv doesn't contain a study that is in the DB.
When looking-up image counts (to display in the auto-complete panel) the `containers` which is coming from the studies.tsv is `undefined` if the study ID is not found in `studies.tsv` - idr-next currently has `idr0141` which is missing from  https://raw.githubusercontent.com/IDR/idr.openmicroscopy.org/master/_data/studies.tsv

This gives the following error in console:

![Screenshot 2022-09-23 at 10 28 31](https://user-images.githubusercontent.com/900055/191932230-55e20949-3c67-4201-8d23-3e4d9020be97.png)

The code fix moves a check for this to *before* the `containers.filter()` that generates the bug.