### PR TITLE
Fix selection of experiments/screens auto-complete item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+3.9.1 (February 2023)
+---------------------
+
+- Fix selection of Experiments/Screens auto-complete item [#25](https://github.com/IDR/idr-gallery/pull/25)
 
 3.9.0 (February 2023)
 ---------------------

--- a/idr_gallery/static/idr_gallery/omero_search_form.js
+++ b/idr_gallery/static/idr_gallery/omero_search_form.js
@@ -63,11 +63,13 @@ const NAME_KEY = "name";
 // display this on the keyFields <select> in place of "name" key
 const NAME_IDR_NUMBER = "Name (IDR number)";
 
+const CONTAINER_TYPE = "container";
+
 const DISPLAY_TYPES = {
   image: "image",
   project: "experiment",
   screen: "screen",
-  "experiments/screens": "experiments/screen",
+  container: "experiments/screen",
 };
 
 // projects or screens might match Name or Description.
@@ -199,7 +201,7 @@ async function getAutoCompleteResults(key, query, knownKeys, operator) {
       // we have duplicate result for project & screen - simply add counts
       console.log("Combining", obj, projectScreenHits[id]);
       projectScreenHits[id].count = projectScreenHits[id].count + obj.count;
-      projectScreenHits[id].type = "experiments/screens";
+      projectScreenHits[id].type = CONTAINER_TYPE;
     }
   });
   console.log("projectScreenHits", projectScreenHits);
@@ -267,7 +269,7 @@ async function getAutoCompleteResults(key, query, knownKeys, operator) {
     // result.dtype can be 'project', 'screen', 'experiments/screens'
     if (result.dtype == "project" || result.dtype == "screen") {
       if (!keyCounts[key].type.includes(result.dtype)) {
-        keyCounts[key].type = "experiments/screens";
+        keyCounts[key].type = CONTAINER_TYPE;
       }
     }
     keyCounts[key].count += result.count;
@@ -600,7 +602,7 @@ class OmeroSearchForm {
     let $select = $(".keyFields", $parent);
     if ($(`option[value='${key}']`, $select).length == 0) {
       // update this.resources_data and re-render <select>
-      if (resource == "container") {
+      if (resource == CONTAINER_TYPE) {
         resource = "project";
       }
       this.resources_data[resource].push(key);


### PR DESCRIPTION
To test:

With "Any" key, enter "Mus mus" and choose the `Organism contains mus musculus (30 experiments/screens)` option:

![Screenshot 2023-02-02 at 17 08 26](https://user-images.githubusercontent.com/900055/216393800-b96e433d-d281-4de2-8f3f-0e9818d00499.png)

This should work as expected and perform a search.
(currently this breaks with error in console):

```
Uncaught TypeError: Cannot read properties of undefined (reading 'push')
    at OmeroSearchForm.setKeyField (omero_search_form.js?_=3.9.0:606:37)
    at HTMLInputElement.select (omero_search_form.js?_=3.9.0:570:18)
```
