### PR TITLE
Handle /search/?query=foo with no key:value

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -15,9 +15,8 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           # This is important to fetch the changes to the previous commit
           fetch-depth: 0
-
       - name: Prettify code
-        uses: creyD/prettier_action@v4.2
+        uses: creyD/prettier_action@v4.3
         with:
           dry: true
           # This part is also where you can pass other options, for example:

--- a/idr_gallery/views.py
+++ b/idr_gallery/views.py
@@ -1,5 +1,5 @@
 
-from django.http import HttpResponseRedirect
+from django.http import HttpResponseRedirect, Http404
 from django.urls import reverse, NoReverseMatch
 import json
 import logging
@@ -77,6 +77,7 @@ def index(request, super_category=None, conn=None, **kwargs):
                                             value=keyval[1],
                                             resource="container",
                                             operator="contains")
+            raise Http404("Query should be ?query=key:value format")
     context = {'template': template}
     context["idr_images"] = IDR_IMAGES
     if super_category == "cell":

--- a/idr_gallery/views.py
+++ b/idr_gallery/views.py
@@ -100,7 +100,9 @@ def index(request, super_category=None, conn=None, **kwargs):
 
 
 def find_mapr_key_value(request, query):
-    key_val = query.split(":")
+    key_val = query.split(":", 1)
+    if len(key_val) < 2:
+        return None
     mapr_key = key_val[0].replace("mapr_", "")
     mapr_value = key_val[1]
     if mapr_settings and mapr_key in mapr_settings.MAPR_CONFIG:

--- a/idr_gallery/views.py
+++ b/idr_gallery/views.py
@@ -1,5 +1,5 @@
 
-from django.http import HttpResponseRedirect, Http404
+from django.http import HttpResponseRedirect, HttpResponseBadRequest
 from django.urls import reverse, NoReverseMatch
 import json
 import logging
@@ -77,7 +77,7 @@ def index(request, super_category=None, conn=None, **kwargs):
                                             value=keyval[1],
                                             resource="container",
                                             operator="contains")
-            raise Http404("Query should be ?query=key:value format")
+            return HttpResponseBadRequest("Query should be ?query=key:value format")
     context = {'template': template}
     context["idr_images"] = IDR_IMAGES
     if super_category == "cell":

--- a/idr_gallery/views.py
+++ b/idr_gallery/views.py
@@ -77,7 +77,8 @@ def index(request, super_category=None, conn=None, **kwargs):
                                             value=keyval[1],
                                             resource="container",
                                             operator="contains")
-            return HttpResponseBadRequest("Query should be ?query=key:value format")
+            return HttpResponseBadRequest(
+                "Query should be ?query=key:value format")
     context = {'template': template}
     context["idr_images"] = IDR_IMAGES
     if super_category == "cell":

--- a/idr_gallery/views.py
+++ b/idr_gallery/views.py
@@ -50,6 +50,7 @@ def index(request, super_category=None, conn=None, **kwargs):
     # template is different for '/search' page
     template = "idr_gallery/index.html"
     if "search" in request.path:
+        template = "idr_gallery/search.html"
         query = request.GET.get("query")
         # Handle old URLs e.g. ?query=mapr_gene:PAX7
         if query:
@@ -66,17 +67,16 @@ def index(request, super_category=None, conn=None, **kwargs):
             # handle e.g. ?query=Publication%20Authors:smith
             # ?key=Publication+Authors&value=Smith&operator=contains&resource=container
             keyval = query.split(":", 1)
-            # search for studies ("containers") and use "contains"
-            # to match previous behaviour
-            # NB: 'Name' needs to be 'name' for search-engine
-            key = "name" if keyval[0] == "Name" else keyval[0]
-            return redirect_with_params('idr_gallery_search',
-                                        key=key,
-                                        value=keyval[1],
-                                        resource="container",
-                                        operator="contains")
-        else:
-            template = "idr_gallery/search.html"
+            if len(keyval) > 1 and len(keyval[1]) > 0:
+                # search for studies ("containers") and use "contains"
+                # to match previous behaviour
+                # NB: 'Name' needs to be 'name' for search-engine
+                key = "name" if keyval[0] == "Name" else keyval[0]
+                return redirect_with_params('idr_gallery_search',
+                                            key=key,
+                                            value=keyval[1],
+                                            resource="container",
+                                            operator="contains")
     context = {'template': template}
     context["idr_images"] = IDR_IMAGES
     if super_category == "cell":


### PR DESCRIPTION
Fixes #17.

Now if the query is not a valid `key` and `value` like `/search/?query=key:value` then it is ignored since we can't perform a search.