### PR TITLE
Handle mapr redirect when no results found

### DIFF
--- a/idr_gallery/views.py
+++ b/idr_gallery/views.py
@@ -114,8 +114,11 @@ def find_mapr_key_value(request, query):
                 all_keys = [key for key in all_keys if key in matching_keys]
             if len(all_keys) > 1 and default_key in all_keys:
                 mapann_key = default_key
-            else:
+            elif len(all_keys) == 1:
                 mapann_key = all_keys[0]
+            else:
+                # no matches -> use default
+                mapann_key = default_key
         return mapann_key, mapr_value
     return None
 


### PR DESCRIPTION
Fixes error when you choose an "Image Attribute" from front page, enter a non-existing value into auto-complete (no results returned) and hit enter.

This tries to load e.g. https://idr.openmicroscopy.org/search/?query=mapr_gene:fakevalue which currently gives an error.

```
  File "/opt/omero/web/venv3/lib64/python3.6/site-packages/idr_gallery/views.py", line 118, in find_mapr_key_value
    mapann_key = all_keys[0]

IndexError: list index out of range
```

With this fix, the redirect should work and provide a results page (showing no results) e.g.
`/search/?key=Gene+Symbol&value=fakevalue&operator=contains`