### PR TITLE
Front page mapr removal

### DIFF
--- a/idr_gallery/static/idr_gallery/autocomplete.js
+++ b/idr_gallery/static/idr_gallery/autocomplete.js
@@ -199,19 +199,19 @@ $("#maprQuery")
         case_sensitive: case_sensitive,
       };
       let url;
-      // NB: Don't use mapr for some slow queries
-      if (configId === "any" || configId === "cellline") {
+      // We use searchengine for ALL backend queries...
+      // if (configId === "any" || configId === "cellline") {
         // Use searchengine...
         url = `${SEARCH_ENGINE_URL}resources/image/searchvalues/`;
         requestData = { value: request.term };
-      } else {
-        // Use mapr to find auto-complete matches TODO: to be removed
-        url = `${BASE_URL}mapr/api/autocomplete/${configId}/`;
-        requestData.value = case_sensitive
-          ? request.term
-          : request.term.toLowerCase();
-        requestData.query = true; // use a 'like' HQL query
-      }
+      // } else {
+      //   // Use mapr to find auto-complete matches TODO: to be removed
+      //   url = `${BASE_URL}mapr/api/autocomplete/${configId}/`;
+      //   requestData.value = case_sensitive
+      //     ? request.term
+      //     : request.term.toLowerCase();
+      //   requestData.query = true; // use a 'like' HQL query
+      // }
       showSpinner();
       $.ajax({
         dataType: "json",
@@ -223,9 +223,10 @@ $("#maprQuery")
           let queryVal = $("#maprQuery").val().trim();
           let results = [];
           // check that input hasn't changed during the call
-          if ((configId === "any" || configId === "cellline") && request.term.trim() == queryVal) {
+          if (request.term.trim() == queryVal) {
             let filterImageKeys;
             if (allKeys) {
+              // if we've chosen a Mapr-key to filter results...
               filterImageKeys = allKeys.split(",");
             }
             autoCompleteDisplayResults(queryVal, data, filterImageKeys);

--- a/idr_gallery/static/idr_gallery/autocomplete.js
+++ b/idr_gallery/static/idr_gallery/autocomplete.js
@@ -92,7 +92,7 @@ function autoCompleteDisplayResults(queryVal, data, filterImageKeys) {
   const highlightStudy = results.length === 0;
   let studiesHtml = ""
   if (!filterImageKeys) {
-    getMatchingStudiesHtml(queryVal, highlightStudy);
+    studiesHtml = getMatchingStudiesHtml(queryVal, highlightStudy);
   } else {
     results = results.filter(res => filterImageKeys.includes(res.Key));
   }

--- a/idr_gallery/static/idr_gallery/autocomplete.js
+++ b/idr_gallery/static/idr_gallery/autocomplete.js
@@ -195,23 +195,10 @@ $("#maprQuery")
       configId = configId.replace("mapr_", "");
       let case_sensitive = false;
 
-      let requestData = {
-        case_sensitive: case_sensitive,
-      };
-      let url;
       // We use searchengine for ALL backend queries...
-      // if (configId === "any" || configId === "cellline") {
-        // Use searchengine...
-        url = `${SEARCH_ENGINE_URL}resources/image/searchvalues/`;
-        requestData = { value: request.term };
-      // } else {
-      //   // Use mapr to find auto-complete matches TODO: to be removed
-      //   url = `${BASE_URL}mapr/api/autocomplete/${configId}/`;
-      //   requestData.value = case_sensitive
-      //     ? request.term
-      //     : request.term.toLowerCase();
-      //   requestData.query = true; // use a 'like' HQL query
-      // }
+      let url = `${SEARCH_ENGINE_URL}resources/image/searchvalues/`;
+      let requestData = { value: request.term };
+
       showSpinner();
       $.ajax({
         dataType: "json",

--- a/idr_gallery/static/idr_gallery/categories.js
+++ b/idr_gallery/static/idr_gallery/categories.js
@@ -343,8 +343,9 @@ async function init() {
 
       let options = FILTER_MAPR_KEYS.map((key) => {
         let config = mapr_settings[key];
+        let allKeys = config.all.join(",");
         if (config) {
-          return `<option value="mapr_${key}">${config.label}</option>`;
+          return `<option value="mapr_${key}" data-allkeys="${allKeys}">${config.label}</option>`;
         } else {
           return "";
         }

--- a/idr_gallery/templates/idr_gallery/base.html
+++ b/idr_gallery/templates/idr_gallery/base.html
@@ -19,13 +19,15 @@
         <link href="{% static 'idr_gallery/css/idr.css' %}?_={{VERSION}}" rel="stylesheet">
         <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.8.1/css/all.css" integrity="sha384-50oBUHEmvpQ+1lW4y57PTFmhCaXp0ML5d60M1M7uH2+nqUivzIebhndOJK28anvf" crossorigin="anonymous">
         <!-- Babel polfill (Symbol, Promise) -->
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-core/5.6.15/browser-polyfill.min.js"></script>
-        <script src="https://code.jquery.com/jquery-2.2.4.min.js"></script>
-        <script src="https://code.jquery.com/ui/1.12.1/jquery-ui.min.js"></script>
-        <link href="https://code.jquery.com/ui/1.12.1/themes/base/jquery-ui.css" rel="stylesheet">
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-core/5.6.15/browser-polyfill.min.js" crossorigin="anonymous"></script>
+        <script src="https://code.jquery.com/jquery-2.2.4.js"
+            integrity="sha256-iT6Q9iMJYuQiMWNd9lDyBUStIq/8PuOW33aOqmvFpqI="
+            crossorigin="anonymous"></script>
+        <script src="https://code.jquery.com/ui/1.12.1/jquery-ui.min.js" crossorigin="anonymous"></script>
+        <link href="https://code.jquery.com/ui/1.12.1/themes/base/jquery-ui.css" rel="stylesheet" crossorigin="anonymous">
 
         <script src="{% static 'idr_gallery/3rdparty/foundation/foundation.min.js' %}"></script>
-        <script src="{{ base_url }}about/js/version.js"></script>
+        <script src="{{ base_url }}about/js/version.js" crossorigin="anonymous"></script>
 
 
         <script src="{% static 'idr_gallery/model.js' %}?_={{VERSION}}"></script>

--- a/idr_gallery/templates/idr_gallery/index.html
+++ b/idr_gallery/templates/idr_gallery/index.html
@@ -19,8 +19,8 @@
   const SEARCH_ENGINE_URL = `${BASE_URL}searchengine/api/v1/`;
 </script>
 
-<script src="https://unpkg.com/@popperjs/core@2"></script>
-<script src="https://unpkg.com/tippy.js@6"></script>
+<script src="https://unpkg.com/@popperjs/core@2" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/tippy.js@6" crossorigin="anonymous"></script>
 <link rel="stylesheet" href="https://unpkg.com/tippy.js@6/dist/backdrop.css" />
 <link rel="stylesheet" href="https://unpkg.com/tippy.js@6/themes/light-border.css" />
 


### PR DESCRIPTION
This replaces `mapr` API queries with `searchengine` queries for the front page auto-complete.

We filter results by the chosen Key.

This addresses the issue of slow mapr autocomplete responses.