### PR TITLE
Use searchengine instead of studies.tsv for image counts

### DIFF
--- a/idr_gallery/static/idr_gallery/categories.js
+++ b/idr_gallery/static/idr_gallery/categories.js
@@ -222,7 +222,7 @@ function imageCount(idrId, container) {
   }
 
   let imgCount = containers
-    .map((row) => row["5D Images"])
+    .map((row) => row["image count"])
     .reduce((total, value) => total + parseInt(value, 10), 0);
   return (
     new Intl.NumberFormat().format(imgCount) +
@@ -294,7 +294,7 @@ model.loadStudyStats(IDR_STUDIES_URL, function (stats) {
         console.log("Failed to filter studies stats by category");
       }
     }
-    let imageCounts = containers.map((row) => row["5D Images"]);
+    let imageCounts = containers.map((row) => row["image count"]);
     totalImages = imageCounts.reduce(
       (total, value) => total + parseInt(value, 10),
       0


### PR DESCRIPTION
Currently we load stats from https://raw.githubusercontent.com/IDR/idr.openmicroscopy.org/master/_data/studies.tsv for the IDR gallery home page.
This is used for the total images count, the image count per study (in info panel when hover over thumbnails) as well as the total data size "385 TB".

However, a limitation of this approach is that it requires a PR to update the studies.tsv file for each release.
An alternative to load image counts for studies is to use the searchengine.
A dedicated endpoint for this query doesn't exist, but we can get the data we want by performing a `container` search with a query that matches every container. E.g. name contains "idr".
This is the query used at:
https://idr.openmicroscopy.org/search/?key=name&value=idr&operator=contains&resource=container

It can be seen there that the searchengine query takes 4-5 seconds.
Another issue is that the response doesn't include the size of data in TB.

This PR uses searchengine to load image counts, however:
 - this takes some time - few secs before image counts are shown
 - the data size is not loaded
 - the image counts for individual studies are not populated since this html is generated while we are still waiting for the searchengine response. This could be fixed by updating the html dynamically when the response returns, but I wanted to hold off on this until I know that the above issues are not blockers!

cc @francesw @sbesson 