### PR TITLE
Use ubuntu-22:04 and checkout@v4 in omero_plugin.yml

### DIFF
--- a/.github/workflows/omero_plugin.yml
+++ b/.github/workflows/omero_plugin.yml
@@ -19,11 +19,11 @@ on:
 jobs:
   test:
     name: Run integration tests against OMERO
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22:04
     env:
       STAGE: app
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Checkout omero-test-infra
         uses: actions/checkout@master
         with:

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -5,10 +5,10 @@ on: push
 jobs:
   build-n-publish:
     name: Build and publish Python distribution to PyPI
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
       - name: Build a binary wheel and a source tarball
         run: |
           python -mpip install wheel


### PR DESCRIPTION
Taking some changes from https://github.com/ome/omero-figure/pull/537/files to try and fix build failures at https://github.com/IDR/idr-gallery/actions/runs/8985335098/job/24679106361

```
Collecting wheel
  Downloading wheel-0.43.0-py3-none-any.whl.metadata (2.2 kB)
Downloading wheel-0.43.0-py3-none-any.whl (65 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 65.8/65.8 kB 3.[9](https://github.com/IDR/idr-gallery/actions/runs/8985335098/job/24679106361#step:5:10) MB/s eta 0:00:00
Installing collected packages: wheel
Successfully installed wheel-0.43.0
Traceback (most recent call last):
  File "/home/runner/work/idr-gallery/idr-gallery/setup.py", line 24, in <module>
    from setuptools import setup, find_packages
ModuleNotFoundError: No module named 'setuptools'
Error: Process completed with exit code 1.
```