### PR TITLE
Add redirect for e.g. /mapr/gene/?value=PAX7

### DIFF
--- a/idr_gallery/templates/idr_gallery/search.html
+++ b/idr_gallery/templates/idr_gallery/search.html
@@ -164,6 +164,8 @@
       let operator = searchParams.get("operator") || "equals";
       searchForm.setKeyValueQuery({key, value, operator, resource});
       searchForm.submitSearch();
+    } else if (key) {
+      searchForm.setKeyValueQuery({key, value: "", operator: "contains", resource});
     }
     // 'hidden' support for ?advanced=true to show AND/OR buttons
     let advanced = searchParams.get("advanced");

--- a/idr_gallery/urls.py
+++ b/idr_gallery/urls.py
@@ -1,4 +1,4 @@
-from django.urls import path, re_path
+from django.urls import re_path
 from .gallery_settings import SUPER_CATEGORIES
 
 from . import views
@@ -20,9 +20,8 @@ urlpatterns = [
 
     # handle mapr URLs and redirect to search e.g. /mapr/gene/?value=PAX7
     # First URL is matched by mapr itself, so not used while mapr istalled...
-    path('mapr/<slug:mapr_key>/', views.mapr, name='mapr'),
-    # ..so we add an alternative URL so we can test
-    path('mapr2gallery/<slug:mapr_key>/', views.mapr, name='mapr2gallery'),
+    # we want a regex that matches mapr_key but not favicon
+    re_path(r'^mapr/(?P<mapr_key>(?!favicon)[\w]+)/$', views.mapr, name='mapr'),
 ]
 
 for c in SUPER_CATEGORIES:

--- a/idr_gallery/urls.py
+++ b/idr_gallery/urls.py
@@ -19,7 +19,10 @@ urlpatterns = [
             name='idr_gallery_api_thumbnails'),
 
     # handle mapr URLs and redirect to search e.g. /mapr/gene/?value=PAX7
+    # First URL is matched by mapr itself, so not used while mapr istalled...
     path('mapr/<slug:mapr_key>/', views.mapr, name='mapr'),
+    # ..so we add an alternative URL so we can test
+    path('mapr2gallery/<slug:mapr_key>/', views.mapr, name='mapr2gallery'),
 ]
 
 for c in SUPER_CATEGORIES:

--- a/idr_gallery/urls.py
+++ b/idr_gallery/urls.py
@@ -1,4 +1,4 @@
-from django.urls import re_path
+from django.urls import path, re_path
 from .gallery_settings import SUPER_CATEGORIES
 
 from . import views
@@ -17,6 +17,9 @@ urlpatterns = [
     # Supports e.g. ?project=1&project=2&screen=3
     re_path(r'^gallery-api/thumbnails/$', views.api_thumbnails,
             name='idr_gallery_api_thumbnails'),
+
+    # handle mapr URLs and redirect to search e.g. /mapr/gene/?value=PAX7
+    path('mapr/<slug:mapr_key>/', views.mapr, name='mapr'),
 ]
 
 for c in SUPER_CATEGORIES:

--- a/idr_gallery/views.py
+++ b/idr_gallery/views.py
@@ -149,7 +149,7 @@ def search_engine_keys(request, value, exact_match=False):
     url += f"?value={value}"
     json_data = requests.get(url).json().get("data", [])
     if exact_match:
-        json_data = filter(lambda x: x.get("Value") == value, json_data)
+        json_data = list(filter(lambda x: x.get("Value").lower() == value.lower(), json_data))
     keys = [result.get("Key") for result in json_data]
     return keys
 

--- a/idr_gallery/views.py
+++ b/idr_gallery/views.py
@@ -1,5 +1,5 @@
 
-from django.http import HttpResponseRedirect, HttpResponseBadRequest
+from django.http import HttpResponseRedirect, HttpResponseBadRequest, Http404
 from django.urls import reverse, NoReverseMatch
 import json
 import logging
@@ -110,7 +110,11 @@ def mapr(request, mapr_key):
     Redirect to search page with mapr_key as query
     """
     mapr_value = request.GET.get("value")
+    if mapr_value is None:
+        raise Http404("No value provided")
     keyval = find_mapr_key_value(request, mapr_key, mapr_value, True)
+    if keyval is None:
+        raise Http404("No matching key found")
     return redirect_with_params('idr_gallery_search',
                                 key=keyval[0],
                                 value=keyval[1],

--- a/idr_gallery/views.py
+++ b/idr_gallery/views.py
@@ -56,7 +56,13 @@ def index(request, super_category=None, conn=None, **kwargs):
         if query:
             # if 'mapr' search, redirect to searchengine page
             if query.startswith("mapr_"):
-                keyval = find_mapr_key_value(request, query)
+                key_val = query.split(":", 1)
+                if len(key_val) < 2:
+                    keyval = None
+                else:
+                    mapr_key = key_val[0].replace("mapr_", "")
+                    mapr_value = key_val[1]
+                    keyval = find_mapr_key_value(request, mapr_key, mapr_value)
                 if keyval is not None:
                     # /search/?key=Gene+Symbol&value=pax6&operator=contains
                     # Use "contains" to be consistent with studies search below
@@ -99,35 +105,41 @@ def index(request, super_category=None, conn=None, **kwargs):
     return context
 
 
-def find_mapr_key_value(request, query):
-    key_val = query.split(":", 1)
-    if len(key_val) < 2:
-        return None
-    mapr_key = key_val[0].replace("mapr_", "")
-    mapr_value = key_val[1]
+def mapr(request, mapr_key):
+    """
+    Redirect to search page with mapr_key as query
+    """
+    mapr_value = request.GET.get("value")
+    keyval = find_mapr_key_value(request, mapr_key, mapr_value, True)
+    return redirect_with_params('idr_gallery_search',
+                                key=keyval[0],
+                                value=keyval[1],
+                                operator="equals")
+
+
+def find_mapr_key_value(request, mapr_key, mapr_value, exact_match=False):
     if mapr_settings and mapr_key in mapr_settings.MAPR_CONFIG:
-        if len(key_val) > 0:
-            # Key could be e.g. 'Gene Symbol' or 'Gene Identifier'
-            mapr_config = mapr_settings.MAPR_CONFIG
-            all_keys = mapr_config[mapr_key]["all"]
-            default_key = mapr_config[mapr_key]["default"][0]
-            # if multiple keys e.g. 'Gene Symbol' or 'Gene Identifier'
-            if len(all_keys) > 1:
-                # need to check which Key matches the Value...
-                matching_keys = search_engine_keys(request, mapr_value)
-                all_keys = [key for key in all_keys if key in matching_keys]
-            if len(all_keys) > 1 and default_key in all_keys:
-                mapann_key = default_key
-            elif len(all_keys) == 1:
-                mapann_key = all_keys[0]
-            else:
-                # no matches -> use default
-                mapann_key = default_key
+        # Key could be e.g. 'Gene Symbol' or 'Gene Identifier'
+        mapr_config = mapr_settings.MAPR_CONFIG
+        all_keys = mapr_config[mapr_key]["all"]
+        default_key = mapr_config[mapr_key]["default"][0]
+        # if multiple keys e.g. 'Gene Symbol' or 'Gene Identifier'
+        if len(all_keys) > 1:
+            # need to check which Key matches the Value...
+            matching_keys = search_engine_keys(request, mapr_value, exact_match)
+            all_keys = [key for key in all_keys if key in matching_keys]
+        if len(all_keys) > 1 and default_key in all_keys:
+            mapann_key = default_key
+        elif len(all_keys) == 1:
+            mapann_key = all_keys[0]
+        else:
+            # no matches -> use default
+            mapann_key = default_key
         return mapann_key, mapr_value
     return None
 
 
-def search_engine_keys(request, value):
+def search_engine_keys(request, value, exact_match=False):
     # find keys that are match the given value
     if settings.BASE_URL is not None:
         base_url = settings.BASE_URL
@@ -136,6 +148,8 @@ def search_engine_keys(request, value):
     url = f"{base_url}searchengine/api/v1/resources/image/searchvalues/"
     url += f"?value={value}"
     json_data = requests.get(url).json().get("data", [])
+    if exact_match:
+        json_data = filter(lambda x: x.get("Value") == value, json_data)
     keys = [result.get("Key") for result in json_data]
     return keys
 
@@ -253,6 +267,11 @@ def api_thumbnails(request, conn=None, **kwargs):
     image_ids = {}
     for obj_type, ids in zip(['project', 'screen'], [project_ids, screen_ids]):
         for obj_id in ids:
+            try:
+                int(obj_id)
+            except ValueError:
+                logger.debug("api_thumbnails Invalid object ID %s" % obj_id)
+                continue
             images = _get_study_images(conn, obj_type, obj_id,
                                        tag_text="Study Example Image")
             if len(images) == 0:


### PR DESCRIPTION
This provides support for URLs that correspond to omero-mapr URLs containing key and value of the form:

```
/mapr/gene/?value=PAX7
```
and also the "home" page for each key, e.g.
```
/mapr/gene/
```

We handle them in this PR at e.g.
```
/idr-gallery/mapr/gene/?value=PAX7
/idr-gallery/mapr/gene/
```

But, since `/idr-gallery/` is deployed for IDR as the "root" app (so that the `/idr-gallery/` home page is `/`) the `/idr-gallery/mapr/gene/?value=PAX7` page is actually at `/mapr/gene/?value=PAX7` and replaces mapr at the same URL (no redirect needed).

This requires that `idr-gallery` is listed in `omero.web.apps` *BEFORE* omero-mapr. 

# changes made to idr-deployment (to be copied to playbooks):
I have deployed this change (ordering of omero.web.apps) on idr-testing.
For each omeroreadonly-1-4 (and omeroreadwrite):

```
$ sudo vi /opt/omero/web/config/omero-web-apps.omero
$ sudo service omero-web restart
```

`omero-web-apps.omero:`
```
# add application
config append -- omero.web.apps '"omero_iviewer"'
config append -- omero.web.apps '"idr_gallery"'
config append -- omero.web.apps '"omero_figure"'
config append -- omero.web.apps '"omero_mapr"'
...
```
Also needed to disable mapr caching on the idr-testing proxy server
```
$ sudo vi /etc/nginx/conf.d/proxy-cache.conf
# comment out line: "~mapr/*" omeromapr;
$ sudo systemctl reload nginx
```

Alternatively, we can use `/mapr2gallery/` instead of `/mapr/` to avoid uncertainty about caching, since the same behaviour is provided at both URLs. E.g.

```
/mapr2gallery/gene/?value=PAX7
/mapr2gallery/gene/
```

In these examples, the key is an identifier of a mapr config: e.g. `gene` config is:

```
{"menu": "gene", "config": {
  "default": ["Gene Symbol"], "all": ["Gene Symbol", "Gene Identifier"],
  "ns": ["openmicroscopy.org/mapr/gene"], "wildcard": {"enabled": true},
  "case_sensitive": "true", "label": "Gene"
}}'
```
We need to know the correct Key to use for the Search engine. In this case there are 2 possible keys: `"Gene Symbol", "Gene Identifier"` so we use the searchengine to find keys that match the Value e.g. https://idr.openmicroscopy.org/searchengine/api/v1/resources/image/searchvalues/?value=PAX7
This allows us to pick "Gene Symbol" as the correct key.

Then we redirect to `idr_gallery/search/?key=Gene+Symbol&value=PAX7&operator=equals` using the `equals` operator since we want to show only *exact* matches.

To test: See testing sheet (Sheet 2) at https://docs.google.com/spreadsheets/d/1cPtsMSMY-5Rd-ob8xA9XCJrmogO6glGt5kM9_8ISONY/edit?gid=1203223646#gid=1203223646

 - Pick a mapr category at idr-testing e.g. "Gene" from the top link. If it doesn't open in idr-gallery search page, then add a cache-busting query. e.g. https://idr-testing.openmicroscopy.org/mapr/gene/?_=_ 
 - This should open e.g. `/search/?key=Gene+Symbol&operator=contains` with the primary attribute  e.g. `Gene Symbol` selected.
 - Perform any search to find images with that key-value pair in the right panel.
 - Copy the URL(s) E.g. gene Identifier `/mapr/gene/?value=YFL009W` and Gene Symbol `/mapr/gene/?value=CDC4` and open in a new tab (or just click on the link)
 - If you see a mapr page instead of the search page, then replace `/mapr/` in the URL with `/mapr2gallery/` or add e.g. `&test=abc123`.
 - Should now get redirected to the search page that shows the same results that mapr does (in IDR).
 
Previously tested:
 - /mapr/gene/?value=Cbx5 
 - /mapr/gene/?value=ENSMUSG00000009575  (needed bc52d14)
 - /mapr/organism/?value=Mus%20musculus - minor numbers mismatch E.g. compare https://idr.openmicroscopy.org/search/?key=Organism&value=Mus+musculus&operator=equals `Mus musculus found 135159 images in 34 experiments` and https://idr.openmicroscopy.org/mapr/organism/?value=Mus%20musculus `Mus musculus (134972) [34]`
 - /mapr/cellline/?value=C127
 - /mapr/compound/?value=MLN8054
 - /mapr/phenotype/?value=CMPO_0000278
 - /mapr/phenotype/?value=motile%20lamellae
 - /mapr/sirna/?value=ACTB
 - /mapr/sirna/?value=ACTB%20pool