### PR TITLE
Fix autocomplete studies

### DIFF
--- a/idr_gallery/static/idr_gallery/css/search_form_styles.css
+++ b/idr_gallery/static/idr_gallery/css/search_form_styles.css
@@ -148,7 +148,10 @@
     background-color: #ddd;
   }
   .studyThumb img:hover {
-    border: solid 4px #64a3e1;
+    border: solid 3px #64a3e1;
+  }
+  .studyThumb .selected img {
+    border: solid 5px #64a3e1;
   }
   .imgLinks {
     position: absolute;

--- a/idr_gallery/static/idr_gallery/css/search_form_styles.css
+++ b/idr_gallery/static/idr_gallery/css/search_form_styles.css
@@ -147,6 +147,9 @@
     position: relative;
     background-color: #ddd;
   }
+  .studyThumb img:hover {
+    border: solid 1px #1976d2;
+  }
   .imgLinks {
     position: absolute;
     background: transparent;

--- a/idr_gallery/static/idr_gallery/css/search_form_styles.css
+++ b/idr_gallery/static/idr_gallery/css/search_form_styles.css
@@ -148,7 +148,7 @@
     background-color: #ddd;
   }
   .studyThumb img:hover {
-    border: solid 1px #1976d2;
+    border: solid 4px #64a3e1;
   }
   .imgLinks {
     position: absolute;

--- a/idr_gallery/static/idr_gallery/omero_search_form.js
+++ b/idr_gallery/static/idr_gallery/omero_search_form.js
@@ -856,12 +856,12 @@ class OmeroSearchForm {
         return `<li class="studyRow" data-name="${studyName}">
             <div class="studyColumns">
                 <div class="caret"><i class="fa fa-caret-right"></i></div>
-                <div class="studyId">
-                  <a href="${BASE_URL}webclient/?show=${objType}-${objId}" target="_blank">${studyId}</a></div>
+                <div class="studyId">${studyId}</div>
                 <div class="count">${count}</div>
                 <div class="studyName" title="${title}">${title}</div>
             </div>
             <div class="studyImages">
+              <div style="margin-left: 20px">Open study: <a href="${BASE_URL}webclient/?show=${objType}-${objId}" target="_blank">${studyName}</a></div>
               <ul></ul>
               <div class="studyImagesSpinner">
                 ${SPINNER_SVG}

--- a/idr_gallery/static/idr_gallery/omero_search_form.js
+++ b/idr_gallery/static/idr_gallery/omero_search_form.js
@@ -784,6 +784,7 @@ class OmeroSearchForm {
   submitSearch() {
     console.log("Submit search...");
     let query = this.getCurrentQuery();
+    console.log(JSON.stringify(query));
     if (!this.validateQuery(query)) {
       console.log("Form not valid");
       return;

--- a/idr_gallery/static/idr_gallery/omero_search_form.js
+++ b/idr_gallery/static/idr_gallery/omero_search_form.js
@@ -861,7 +861,10 @@ class OmeroSearchForm {
                 <div class="studyName" title="${title}">${title}</div>
             </div>
             <div class="studyImages">
-              <div style="margin-left: 20px">Open study: <a href="${BASE_URL}webclient/?show=${objType}-${objId}" target="_blank">${studyName}</a></div>
+              <div style="margin-left: 20px">
+                Images from study: <a href="${BASE_URL}webclient/?show=${objType}-${objId}" target="_blank" title="Open Study in webclient showing ALL images">
+                  ${studyName}</a>
+              </div>
               <ul></ul>
               <div class="studyImagesSpinner">
                 ${SPINNER_SVG}

--- a/idr_gallery/static/idr_gallery/omero_search_form.js
+++ b/idr_gallery/static/idr_gallery/omero_search_form.js
@@ -939,8 +939,8 @@ class OmeroSearchForm {
       .map((img) => {
         // Each thumbnail links to image viewer. Hover menu links to viewer (eye) and webclient (i)
         return `<li class="studyThumb">
-          <a target="_blank" href="${BASE_URL}webclient/img_detail/${img.id}">
-            <img title="${img.name}" src="${BASE_URL}webclient/render_thumbnail/${img.id}/" loading="lazy" />
+          <a class="thumblink" data-image_id="${img.id}" data-image_name="${img.name}" target="_blank" href="${BASE_URL}webclient/img_detail/${img.id}">
+            <img data-image_id="${img.id}" data-image_name="${img.name}" title="${img.name}" src="${BASE_URL}webclient/render_thumbnail/${img.id}/" loading="lazy" />
           </a>
           <ul class="imgLinks">
             <li title="Browse image metadata">

--- a/idr_gallery/static/idr_gallery/omero_search_form.js
+++ b/idr_gallery/static/idr_gallery/omero_search_form.js
@@ -168,14 +168,15 @@ async function getAutoCompleteResults(key, query, knownKeys, operator) {
   let kvp_url = `${SEARCH_ENGINE_URL}resources/all/searchvalues/?` + params;
   let urls = [kvp_url];
 
-  // We always check for Names...
-  // Need to load data from 2 end-points
-  let names_url = `${SEARCH_ENGINE_URL}resources/all/names/?value=${query}`;
-  // NB: Don't show auto-complete for Description yet - issues with 'equals' search
-  // if (key == "Any" || key == "description") {
-  //   names_url += `&use_description=true`;
-  // }
-  urls.push(names_url);
+  // We check for Names if "Any"
+  if (key == "Any") {
+    let names_url = `${SEARCH_ENGINE_URL}resources/all/names/?value=${query}`;
+    // NB: Don't show auto-complete for Description yet - issues with 'equals' search
+    // if (key == "Any" || key == "description") {
+    //   names_url += `&use_description=true`;
+    // }
+    urls.push(names_url);
+  }
 
   const promises = urls.map((p) => fetch(p).then((rsp) => rsp.json()));
   const responses = await Promise.all(promises);

--- a/idr_gallery/templates/idr_gallery/search.html
+++ b/idr_gallery/templates/idr_gallery/search.html
@@ -150,6 +150,13 @@
   .map_ann table {
     margin: 0;
   }
+  .favion img {
+    border: 1px solid hsl(210, 8%, 65%);
+    box-shadow: 0 1px 0 rgba(255, 255, 255, 0.5);
+    vertical-align: middle;
+    width: 15px;
+    height: 15px;
+  }
 </style>
 
 <link rel="stylesheet" href="{% static 'idr_gallery/css/search_form_styles.css' %}?_={{VERSION}}" />
@@ -332,6 +339,23 @@
           ns2menu[obj.ns] = obj.label;
         });
 
+        // Combine e.g. "Gene Identifier" and following "Gene Identifier URL" into one
+        anns = anns.map((ann, i) => {
+          ann.values = ann.values.map((kv, idx) => {
+            if (ann.values[idx + 1] && ann.values[idx + 1][0] === kv[0] + " URL") {
+              let url = ann.values[idx + 1][1];
+              // Add URL to kvp
+              kv = [...kv, url];
+            }
+            return kv;
+          });
+          ann.values = ann.values.filter((kv, idx) => {
+            // if the previous kvp have URL, skip this one
+            return !(idx > 0 && ann.values[idx - 1][2]);
+          });
+          return ann;
+        });
+
         // Update html...
         let html = anns.map(ann => {
           return `
@@ -348,6 +372,9 @@
                     <td>${v[0]}</td>
                     <td>
                       <a href="/search/?key=${encodeURIComponent(v[0])}&value=${encodeURIComponent(v[1])}&operator=equals&resource=image">${v[1]}</a>
+                      ${v[2] ? `<span class='favicon'><a href="${v[2]}" target="_blank">
+                        <img src="/mapr/favicon/?u=${v[2]}">
+                      </a></span>` : ""}
                     </td>
                   </tr>`
                 }).join("")}

--- a/idr_gallery/templates/idr_gallery/search.html
+++ b/idr_gallery/templates/idr_gallery/search.html
@@ -105,6 +105,9 @@
   }
   #kvp_popover_content a {
     font-weight: normal;
+  }
+  #popover_links a {
+    font-weight: normal;
     display: inline-block;
     border: solid #ccc 1px;
     padding: 5px;
@@ -343,7 +346,9 @@
                 ${ann.values.map(v => {
                   return `<tr>
                     <td>${v[0]}</td>
-                    <td>${v[1]}</td>
+                    <td>
+                      <a href="/search/?key=${encodeURIComponent(v[0])}&value=${encodeURIComponent(v[1])}&operator=equals&resource=image">${v[1]}</a>
+                    </td>
                   </tr>`
                 }).join("")}
                 </tbody>

--- a/idr_gallery/templates/idr_gallery/search.html
+++ b/idr_gallery/templates/idr_gallery/search.html
@@ -371,7 +371,9 @@
                   return `<tr>
                     <td>${v[0]}</td>
                     <td>
-                      <a href="/search/?key=${encodeURIComponent(v[0])}&value=${encodeURIComponent(v[1])}&operator=equals&resource=image">${v[1]}</a>
+                      <a title="Search for images with ${v[0]}: ${v[1]}" href="/search/?key=${encodeURIComponent(v[0])}&value=${encodeURIComponent(v[1])}&operator=equals&resource=image">
+                        ${v[1]}
+                      </a>
                       ${v[2] ? `<span class='favicon'><a href="${v[2]}" target="_blank">
                         <img src="/mapr/favicon/?u=${v[2]}">
                       </a></span>` : ""}

--- a/idr_gallery/templates/idr_gallery/search.html
+++ b/idr_gallery/templates/idr_gallery/search.html
@@ -102,6 +102,10 @@
     flex: auto 0 0;
     margin: 10px;
   }
+  #kvp_popover_content th h2 {
+    font-size: 15px;
+    margin: 0;
+  }
   #kvp_popover_content a {
     font-weight: normal;
     display: inline-block;
@@ -127,11 +131,11 @@
       width: 100%;
     }
   }
-  .map_ann tr {
+  .map_ann tbody tr {
     background: hsl(220,20%,95%);
     border: solid #ddd 1px;
   }
-  .map_ann td {
+  .map_ann td, .map_ann th {
     padding: 2px;
     background-color: hsl(220,20%,95%);
     width: 50%;
@@ -142,6 +146,9 @@
   .map_ann {
     padding: 5px;
     margin: 5px;
+  }
+  .map_ann table {
+    margin: 0;
   }
 </style>
 
@@ -289,7 +296,7 @@
         <a target="_blank" href="${BASE_URL}webclient/img_detail/${image_id}">
           Open Image in Viewer<i class="fas fa-eye"></i></a></div>`
     document.getElementById("popover_links").innerHTML = linkshtml;
-    
+
     let url = `https://idr.openmicroscopy.org/webclient/api/annotations/?type=map&image=${image_id}`;
     fetch(url)
       .then(response => response.json())
@@ -321,18 +328,32 @@
         // Populate experimenters within anns
         var anns = data.annotations.map(populate_experimenter);
 
+        // Replace namespace with label
+        var ns2menu = {};
+        Object.entries(MAPR_CONFIG).forEach(([key, obj]) => {
+          ns2menu[obj.ns] = obj.label;
+        });
+        console.log("ns2menu", ns2menu);
+
         // Update html...
         console.log("anns", anns);
         let html = anns.map(ann => {
           return `
             <div class="map_ann">
               <table>
+                <thead>
+                <tr title="${ann.ns}">
+                  <th colspan="2"><h2>${ns2menu[ann.ns] || ann.ns}</h2></th>
+                </tr>
+                </thead>
+                <tbody>
                 ${ann.values.map(v => {
                   return `<tr>
                     <td>${v[0]}</td>
                     <td>${v[1]}</td>
                   </tr>`
                 }).join("")}
+                </tbody>
               </table>
             </div>`
         });
@@ -340,6 +361,12 @@
         document.getElementById("popover_kvp").innerHTML = html.join("\n");
       });
   });
+
+  // load mapr config at the start...
+  window.MAPR_CONFIG = {};
+  let maprConigUrl = `https://idr.openmicroscopy.org/mapr/api/config/`;
+  fetch(maprConigUrl).then(response => response.json())
+  .then(data => {window.MAPR_CONFIG = data;});
 
 
   window.onpopstate = (event) => {

--- a/idr_gallery/templates/idr_gallery/search.html
+++ b/idr_gallery/templates/idr_gallery/search.html
@@ -78,12 +78,14 @@
   #kvp_popover {
     margin: auto;
     position: fixed;
-    margin-right: 5px;
-    margin-bottom: 5px;
-    width: 512px;
-    height: 75%;
+    margin-right: 15px;
+    margin-bottom: 15px;
+    width: 400px;
+    height: 65%;
     overflow: auto;
     box-shadow: 5px 4px 10px -5px #737373;
+    border: solid 1px black;
+    border-radius: 10px;
   }
   #kvp_popover_content {
     color: hsl(210, 10%, 30%);
@@ -133,8 +135,9 @@
     padding: 2px;
     background-color: hsl(220,20%,95%);
     width: 50%;
-    max-width: 50%;
+    max-width: 100px;
     overflow-wrap: break-word;
+    overflow: hidden;
   }
   .map_ann {
     padding: 5px;
@@ -321,7 +324,7 @@
         // Update html...
         console.log("anns", anns);
         let html = anns.map(ann => {
-          return `<div class="row">
+          return `
             <div class="map_ann">
               <table>
                 ${ann.values.map(v => {
@@ -330,6 +333,7 @@
                     <td>${v[1]}</td>
                   </tr>`
                 }).join("")}
+              </table>
             </div>`
         });
 

--- a/idr_gallery/templates/idr_gallery/search.html
+++ b/idr_gallery/templates/idr_gallery/search.html
@@ -293,6 +293,9 @@
     event.preventDefault();
     document.getElementById("popover_kvp").innerHTML = `<div style='padding:10px'>Loading Attributes...</div>`;
     document.getElementById("kvp_popover").showPopover();
+    let $thumb = $(event.target);
+    $(".studyThumb a").removeClass("selected");
+    $thumb.parents(".studyThumb").find("a").addClass("selected");
 
     let image_id = event.target.dataset.image_id;
     let image_name = event.target.dataset.image_name;

--- a/idr_gallery/templates/idr_gallery/search.html
+++ b/idr_gallery/templates/idr_gallery/search.html
@@ -284,7 +284,7 @@
 
   $(".resultsList").on("click", "a.thumblink", function(event){
     event.preventDefault();
-    document.getElementById("popover_kvp").innerHTML = "Loading Attributes...";
+    document.getElementById("popover_kvp").innerHTML = `<div style='padding:10px'>Loading Attributes...</div>`;
     document.getElementById("kvp_popover").showPopover();
 
     let image_id = event.target.dataset.image_id;
@@ -300,9 +300,7 @@
     let url = `https://idr.openmicroscopy.org/webclient/api/annotations/?type=map&image=${image_id}`;
     fetch(url)
       .then(response => response.json())
-      .then(data => {
-        console.log("annotations", data);
-        
+      .then(data => {        
         var experimenters = [];
         if (data.experimenters.length > 0) {
             // manipulate data...
@@ -333,10 +331,8 @@
         Object.entries(MAPR_CONFIG).forEach(([key, obj]) => {
           ns2menu[obj.ns] = obj.label;
         });
-        console.log("ns2menu", ns2menu);
 
         // Update html...
-        console.log("anns", anns);
         let html = anns.map(ann => {
           return `
             <div class="map_ann">

--- a/idr_gallery/templates/idr_gallery/search.html
+++ b/idr_gallery/templates/idr_gallery/search.html
@@ -58,6 +58,88 @@
     border-radius: 10px;
     margin: 5px;
   }
+
+  .close {
+    position: absolute;
+    right: 5px;
+    top: 5px;
+    z-index: 100;
+    font-size: 2rem;
+    padding: 2px 9px;
+  }
+  .scrollable {
+    position: absolute;
+    inset: 0;
+    overflow: auto;
+    height: 100%;
+    z-index: 0;
+    padding: 5px;
+  }
+  #kvp_popover {
+    margin: auto;
+    position: fixed;
+    margin-right: 5px;
+    margin-bottom: 5px;
+    width: 512px;
+    height: 75%;
+    overflow: auto;
+    box-shadow: 5px 4px 10px -5px #737373;
+  }
+  #kvp_popover_content {
+    color: hsl(210, 10%, 30%);
+    font-size: 12px;
+    background-color: hsl(220,20%,95%);
+    display: flex;
+    flex-direction: column;
+    z-index: 0;
+  }
+  #kvp_popover_content h2 {
+    font-size: 16px;
+    color: hsl(210, 10%, 30%);
+    inset: 0;
+    flex: auto 0 0;
+    margin: 10px;
+  }
+  #kvp_popover_content a {
+    font-weight: normal;
+    display: inline-block;
+    border: solid #ccc 1px;
+    padding: 5px;
+    border-radius: 10px;
+    background: rgba(256, 256, 256, 0.5);
+  }
+  #kvp_popover_content i.fas {
+    margin: 0 10px;
+  }
+  #popover_links {
+    flex: auto 0 0;
+    margin: 0 10px 10px 10px;
+  }
+  #popover_kvp {
+    flex: auto 1 1;
+    overflow: auto;
+  }
+
+  @media (max-width: 800px) {
+    #mypopover {
+      width: 100%;
+    }
+  }
+  .map_ann tr {
+    background: hsl(220,20%,95%);
+    border: solid #ddd 1px;
+  }
+  .map_ann td {
+    padding: 2px;
+    background-color: hsl(220,20%,95%);
+    width: 50%;
+    max-width: 50%;
+    overflow-wrap: break-word;
+  }
+  .map_ann {
+    padding: 5px;
+    margin: 5px;
+  }
 </style>
 
 <link rel="stylesheet" href="{% static 'idr_gallery/css/search_form_styles.css' %}?_={{VERSION}}" />
@@ -103,6 +185,15 @@
     <ul id="results" class="resultsList"></ul>
 </div>
 
+</div>
+
+<div id="kvp_popover" popover>
+  <button class="close" popovertarget="kvp_popover">&times;</button>
+  <div id="kvp_popover_content" class="scrollable">
+    <h2 id="popover_imagename">Image Name</h2>
+    <div id="popover_links"></div>
+    <div id="popover_kvp"></div>
+  </div>
 </div>
 
 <script>
@@ -179,6 +270,71 @@
 
   searchForm.on("ready", function(){
     searchFromUrl();
+  });
+
+  $(".resultsList").on("click", "a.thumblink", function(event){
+    event.preventDefault();
+    document.getElementById("popover_kvp").innerHTML = "Loading Attributes...";
+    document.getElementById("kvp_popover").showPopover();
+
+    let image_id = event.target.dataset.image_id;
+    let image_name = event.target.dataset.image_name;
+    document.getElementById("popover_imagename").innerHTML = image_name;
+    let linkshtml = `
+        <div><a target="_blank" href="${BASE_URL}webclient/?show=image-${image_id}">
+          Browse image metadata<i class="fas fa-info"></i></a>
+        <a target="_blank" href="${BASE_URL}webclient/img_detail/${image_id}">
+          Open Image in Viewer<i class="fas fa-eye"></i></a></div>`
+    document.getElementById("popover_links").innerHTML = linkshtml;
+    
+    let url = `https://idr.openmicroscopy.org/webclient/api/annotations/?type=map&image=${image_id}`;
+    fetch(url)
+      .then(response => response.json())
+      .then(data => {
+        console.log("annotations", data);
+        
+        var experimenters = [];
+        if (data.experimenters.length > 0) {
+            // manipulate data...
+            // make an object of eid: experimenter
+            experimenters = data.experimenters.reduce(function(prev, exp){
+                prev[exp.id + ""] = exp;
+                return prev;
+            }, {});
+        }
+
+        var populate_experimenter = function(ann) {
+            if (data.experimenters.length > 0) {
+                ann.owner = experimenters[ann.owner.id];
+            }
+            if (ann.link && ann.link.owner) {
+                ann.link.owner = experimenters[ann.link.owner.id];
+                // AddedBy IDs for filtering
+                ann.addedBy = [ann.link.owner.id];
+            }
+            return ann;
+        };
+
+        // Populate experimenters within anns
+        var anns = data.annotations.map(populate_experimenter);
+
+        // Update html...
+        console.log("anns", anns);
+        let html = anns.map(ann => {
+          return `<div class="row">
+            <div class="map_ann">
+              <table>
+                ${ann.values.map(v => {
+                  return `<tr>
+                    <td>${v[0]}</td>
+                    <td>${v[1]}</td>
+                  </tr>`
+                }).join("")}
+            </div>`
+        });
+
+        document.getElementById("popover_kvp").innerHTML = html.join("\n");
+      });
   });
 
 

--- a/idr_gallery/templates/idr_gallery/search.html
+++ b/idr_gallery/templates/idr_gallery/search.html
@@ -297,7 +297,7 @@
           Open Image in Viewer<i class="fas fa-eye"></i></a></div>`
     document.getElementById("popover_links").innerHTML = linkshtml;
 
-    let url = `https://idr.openmicroscopy.org/webclient/api/annotations/?type=map&image=${image_id}`;
+    let url = `${BASE_URL}webclient/api/annotations/?type=map&image=${image_id}`;
     fetch(url)
       .then(response => response.json())
       .then(data => {        
@@ -360,7 +360,7 @@
 
   // load mapr config at the start...
   window.MAPR_CONFIG = {};
-  let maprConigUrl = `https://idr.openmicroscopy.org/mapr/api/config/`;
+  let maprConigUrl = `${BASE_URL}mapr/api/config/`;
   fetch(maprConigUrl).then(response => response.json())
   .then(data => {window.MAPR_CONFIG = data;});
 

--- a/idr_gallery/templates/idr_gallery/search.html
+++ b/idr_gallery/templates/idr_gallery/search.html
@@ -32,9 +32,6 @@
     max-height: 45px;
     max-width: 45px;
   }
-  table td {
-    white-space: nowrap;
-  }
   .filterMessage {
     font-size: 120%;
   }


### PR DESCRIPTION
NB: this branch is on top of #45, making it easier to deploy both together....

# Bug fix:

Fixes #46.
To test, see screenshot on the issue.
E.g. Choose a key (not "Any") in the dropdown list, then type in the auto-complete with text that matches study names e.g. "cell" or "light". You shouldn't see the study names show up at the top of the auto-complete.

# Selected image popup

When you click on a thumbnail, instead of going directly to iviewer in a new Tab, we now show the Key-Value pairs for the image in a popup:

![Screenshot 2024-11-20 at 14 44 54](https://github.com/user-attachments/assets/0a54a2e1-1f5c-4728-a26e-69819fd1c947)


# Studies link
Update: there is another tiny usability fix in this PR: the link to studies has been removed from the top row of search results because I find it really annoying that I keep clicking on this by accident and get taken to the webclient/ showing the study in another Tab, when I really just wanted to expand the results to see the images. 
I have moved the link *inside* the results so you can still click on it once expanded. However, I'm still not sure I like it even there, as it feels like it's part of the results - If I browse to the study I might expect to see *only* the search results within that study (like in mapr) but in fact this will show ALL the images in the study. So maybe we should just remove the link, as you can always find the study when you browse the images?

Before:
![Screenshot 2024-10-30 at 11 59 55](https://github.com/user-attachments/assets/fcd90629-2a0e-44a8-9272-1c9671a4f760)

After:
![Screenshot 2024-10-30 at 11 58 32](https://github.com/user-attachments/assets/2d45cb9e-0321-4dac-b979-5197eaa8bcbe)

