### PR TITLE
Add gallery_api/annotations?ns=foo endpoint

### DIFF
--- a/idr_gallery/urls.py
+++ b/idr_gallery/urls.py
@@ -22,6 +22,10 @@ urlpatterns = [
     re_path(r'^gallery-api/thumbnails/$', views.api_thumbnails,
             name='idr_gallery_api_thumbnails'),
 
+    # Find annotations by namespace ?ns=idr.gallery.etc 
+    path("gallery_api/annotations/", views.api_annotations,
+         name='idr_gallery_annotations'),
+
     # handle mapr URLs and redirect to search e.g. /mapr/gene/?value=PAX7
     # First URL is matched by mapr itself, so not used while mapr istalled...
     # we want a regex that matches mapr_key but not favicon

--- a/idr_gallery/views.py
+++ b/idr_gallery/views.py
@@ -14,7 +14,7 @@ from omero.rtypes import wrap, rlong
 from omeroweb.webclient.decorators import login_required, render_response
 from omeroweb.api.decorators import login_required as api_login_required
 from omeroweb.api.api_settings import API_MAX_LIMIT
-from omeroweb.webclient.tree import marshal_annotations
+from omeroweb.webclient.tree import marshal_annotations, _marshal_annotation
 
 import requests
 
@@ -517,6 +517,39 @@ def api_thumbnails(request, conn=None, **kwargs):
         except KeyError:
             logger.error("Thumbnail not available. (img id: %d)" % i)
     return rv
+
+
+@render_response()
+@api_login_required()   # 403 JsonResponse if not logged in
+def api_annotations(request, conn=None, **kwargs):
+    """
+    Return annotations for a given namespace e.g.
+    ?ns=idr.gallery.etc
+    """
+    ns = request.GET.get("ns")
+    if not ns:
+        return HttpResponseBadRequest("Missing 'ns' query parameter")
+    dtypes = request.GET.getlist("type")
+    if len(dtypes) == 0:
+        return HttpResponseBadRequest("Missing e.g. ?type=project")
+
+    query_service = conn.getQueryService()
+    params = omero.sys.ParametersI()
+    params.addString("ns", ns)
+    anns = []
+    for dtype in dtypes:
+        query = """select oal from %sAnnotationLink as oal
+                join fetch oal.details.creationEvent
+                join fetch oal.details.owner
+                left outer join fetch oal.child as ch
+                left outer join fetch oal.parent as pa
+                join fetch ch.details.creationEvent
+                where ch.ns = :ns""" % dtype.capitalize()
+        result = query_service.findAllByQuery(query, params, conn.SERVICE_OPTS)
+        for link in result:
+            if link.child is not None and link.parent is not None:
+                anns.append(_marshal_annotation(conn, link.child, link))
+    return {"annotations": anns}
 
 
 def get_bff_url(request, data_url, fname, ext="csv"):


### PR DESCRIPTION
Fixes #57 

This is an investigation into how to hide Projects and Screens until we want to publish them in IDR:

Steps:

 - `$ ssh -A -o 'ProxyCommand ssh idr-testing.openmicroscopy.org -W %h:%p' omeroreadwrite -L 1080:localhost:80` then login as `demo` user at local http://localhost:1080/webclient and add e.g. a Comment to Project/Screen.
 - You can see the Comment ID using the browser Dev tools Network tab when re-loading right panel.
 - Then, use CLI to set the namespace on that Comment. 
```
$ omero obj update CommentAnnotation:38359142 ns=idr.gallery.hide
```

We need to inject the following script into main webclient page:
What it does:

 - When the page loads, it makes an immediate request to the endpoint in this PR to load annotations with `ns=idr.gallery.hide` and the IDs of attached Screens and Projects.
 - It then listens for `load_node.jstree` events on the jsTree and filters loaded child nodes to exclude the Screens and Projects that we want to hide

```
<script>
        $(document).ready(function(){
            let projectsToHide = [];
            let screensToHide = [];
            fetch("/gallery_api/annotations/?ns=idr.gallery.hide&type=project&type=screen")
            .then(response => response.json())
            .then(data => {
                data.annotations.forEach(annotation => {
                    console.log("ANNOTATION", annotation);
                    let link = annotation.link;
                    if (link.parent.class === "ProjectI") {
                        projectsToHide.push(link.parent.id);
                    } else if (link.parent.class === "ScreenI") {
                        screensToHide.push(link.parent.id);
                    }
                });
            });
            $("#dataTree").on("load_node.jstree", function(event, data) {
                data.node.children = data.node.children.filter(function(childId){
                    let child = data.instance.get_node(childId);
                    // console.log(child.type === "project", projectsToHide.includes(child.data.id));
                    if ((child.type === "project") && projectsToHide.includes(child.data.id)) {
                        console.log("Hiding project", child.data.id);
                        return false;
                    } else if ((child.type === "screen") && screensToHide.includes(child.data.id)) {
                        console.log("Hiding screen", child.data.id);
                        return false;
                    }
                    return true;
                });
            });
        });
    </script>
```
