### PR TITLE
Searchengine container data url

### DIFF
--- a/idr_gallery/views.py
+++ b/idr_gallery/views.py
@@ -209,7 +209,7 @@ def study_page(request, idrid, format="html", conn=None, **kwargs):
                                            f"{obj.name}.parquet",
                                            ext="parquet"),
             "empty_study_container": ("experiment" not in obj.name
-                                      and "screen" not in obj.name,)
+                                      and "screen" not in obj.name)
         })
 
     img_objects = []

--- a/idr_gallery/views.py
+++ b/idr_gallery/views.py
@@ -188,8 +188,8 @@ def study_page(request, idrid, format="html", conn=None, **kwargs):
             if f"{token} Description" in desc:
                 desc = desc.split(f"{token} Description", 1)[1].strip()
         otype = "project" if obj.OMERO_CLASS == "Project" else "screen"
-        study_bff_url = f"{bff_url}?container_name={obj.name}\
-                        &container_type={otype}"
+        study_bff_url = (f"{bff_url}?container_name={obj.name}" +
+                         f"&container_type={otype}")
         # https://idr-testing.openmicroscopy.org/searchengine//api/v1/resources/
         # container_data/?container_name=idr0164-alzubi-hdbr%2FexperimentA&
         # container_type=project

--- a/idr_gallery/views.py
+++ b/idr_gallery/views.py
@@ -180,7 +180,7 @@ def study_page(request, idrid, format="html", conn=None, **kwargs):
         base_url = settings.BASE_URL
     else:
         base_url = request.build_absolute_uri(reverse('index'))
-    bff_url = f"{base_url}searchengine/api/v1/resources/container_bff_data/"
+    bff_url = f"{base_url}searchengine/api/v1/resources/container_data/"
     containers = []
     for obj in objs:
         desc = obj.description if obj.description is not None else ""
@@ -191,7 +191,7 @@ def study_page(request, idrid, format="html", conn=None, **kwargs):
         study_bff_url = f"{bff_url}?container_name={obj.name}\
                         &container_type={otype}"
         # https://idr-testing.openmicroscopy.org/searchengine//api/v1/resources/
-        # container_bff_data/?container_name=idr0164-alzubi-hdbr%2FexperimentA&
+        # container_data/?container_name=idr0164-alzubi-hdbr%2FexperimentA&
         # container_type=project
 
         containers.append({


### PR DESCRIPTION
Updates URL `container_data` from https://github.com/ome/omero_search_engine/pull/141