### PR TITLE
image/ID/download_urls json endpoint

### DIFF
--- a/idr_gallery/urls.py
+++ b/idr_gallery/urls.py
@@ -14,6 +14,10 @@ urlpatterns = [
     # image landing page
     path("image/<int:iid>/", views.image_landing_page, name='idr_gallery_image'),
 
+    # Get the download URLs for an image
+    path("image/<int:iid>/download_urls/", views.image_download_urls,
+         name='idr_gallery_image_download_urls'),
+
     # All settings as JSON
     re_path(r'^gallery_settings/$', views.gallery_settings),
 

--- a/idr_gallery/views.py
+++ b/idr_gallery/views.py
@@ -591,6 +591,61 @@ def image_landing_page(request, iid, zarr_to_iviewer=False, conn=None, **kwargs)
     return rsp_json
 
 
+@login_required()
+@render_response()
+def image_download_urls(request, iid, conn=None, **kwargs):
+    """
+    Use the download_urls.tsv file to get the download URLs for an image as JSON.
+    """
+
+    image = conn.getObject("Image", iid)
+    if image is None:
+        raise Http404("Image with ID %s not found" % iid)
+
+    rsp_json = {}
+
+    if image.fileset is not None:
+        paths = image.getImportedImageFilePaths()
+        rsp_json["client_paths"] = paths["client_paths"]
+
+    # get parent Project or Screen to get IDRID name
+    parents = image.getAncestry()
+    idrid_name = parents[-1].name  # e.g. idr0002-heriche-condensation/experimentA
+    idrid = idrid_name.split("-")[0]  # e.g. idr0002
+
+    # load tsv from https://raw.githubusercontent.com/IDR/idr.openmicroscopy.org/refs/heads/master/_data/download_urls.tsv
+    # via requests, find column for 'idrid' and row where this matches idrid
+    download_urls_tsv_url = "https://raw.githubusercontent.com/IDR/idr.openmicroscopy.org/refs/heads/master/_data/download_urls.tsv"
+    # allow override via ?tsv=... for testing
+    download_urls_tsv_url = request.GET.get("tsv", download_urls_tsv_url)
+    replace_this = None
+    with_this = None
+    try:
+        response = requests.get(download_urls_tsv_url, timeout=5)
+        response.raise_for_status()
+        tsv_lines = response.text.splitlines()
+        headers = tsv_lines[0].split("\t")
+        idrid_index = headers.index("idrid")
+        replace_index = headers.index("replace_this")
+        with_index = headers.index("with_this")
+        for line in tsv_lines[1:]:
+            columns = line.split("\t")
+            if columns[idrid_index] == idrid:
+                replace_this = columns[replace_index]
+                with_this = columns[with_index]
+                break
+    except requests.RequestException as e:
+        logger.error(f"Error fetching download URLs TSV: {e}")
+        rsp_json["error"] = f"Could not fetch download URLs TSV from {download_urls_tsv_url}"
+
+    if replace_this is not None and with_this is not None:
+        rsp_json["download_urls"] = [path.replace(replace_this, with_this) for path in rsp_json.get("client_paths", [])]
+    else:
+        rsp_json["error"] = f"No matching row found for idrid {idrid} in download URLs TSV"
+
+    return rsp_json
+
+
 def get_bff_url(request, data_url, fname, ext="csv"):
     """
     We build config into query params for the BFF app

--- a/idr_gallery/views.py
+++ b/idr_gallery/views.py
@@ -640,9 +640,10 @@ def image_download_urls(request, iid, conn=None, **kwargs):
 
     if replace_this is not None and with_this is not None:
         rsp_json["download_urls"] = [path.replace(replace_this, with_this) for path in rsp_json.get("client_paths", [])]
-    else:
-        rsp_json["error"] = f"No matching row found for idrid {idrid} in download URLs TSV"
+    elif "error" not in rsp_json:
+        rsp_json["error"] = f"No matching row found for idrid '{idrid}' in download URLs TSV"
 
+    rsp_json["tsv_url"] = download_urls_tsv_url
     return rsp_json
 
 


### PR DESCRIPTION
This adds a JSON endpoint to access the same download_urls that are displayed on the image landing pages.

We use the https://raw.githubusercontent.com/IDR/idr.openmicroscopy.org/refs/heads/master/_data/download_urls.tsv table with the same logic as for the landing pages. For a given row (per study) we use the `replace_this` and `with_this` columns. See https://proxy-idr-ap1.dundee.ac.uk/download_urls/ where this logic is used to generate the URL for the client_path column.

To test:
 - for an image in IDR, go to `/image/ID/download_urls/`
 - JSON response includes `client_paths` from the server, as well as the `download_urls` derived from these by replacing `replace_this` with `with_this`.

NB: This requires a config change for public url regex. `/image` is needed (similar to `/api` etc).